### PR TITLE
[replit] Read model path from `MODEL` environment variable

### DIFF
--- a/examples/replit/app.py
+++ b/examples/replit/app.py
@@ -7,6 +7,7 @@ import multiprocessing
 from functools import partial
 from threading import Lock
 from typing import Dict, List, Optional, Union, Iterator, AsyncIterator, Sequence
+from os import environ
 
 from typing_extensions import TypedDict, Literal
 
@@ -530,7 +531,7 @@ class CreateCompletionRequest(BaseModel):
         }
 
 
-settings = Settings()  # type: ignore
+settings = Settings(model_file=environ.get("MODEL"))
 app = FastAPI(
     title="Code Completion API",
     description="""

--- a/examples/replit/app.py
+++ b/examples/replit/app.py
@@ -531,7 +531,7 @@ class CreateCompletionRequest(BaseModel):
         }
 
 
-settings = Settings(model_file=environ.get("MODEL"))
+settings = Settings(model_file=environ.get("MODEL")) # type: ignore
 app = FastAPI(
     title="Code Completion API",
     description="""


### PR DESCRIPTION
The replit example `README.md` currently contains an example in which the model path is provided via the `MODEL` env variable: https://github.com/abetlen/ggml-python/blob/c4cb698cd2068addafe0b2b4fd3c63b49061f5c8/examples/replit/README.md?plain=1#L29

This PR adds this functionality. Should solve: https://github.com/abetlen/ggml-python/issues/11