### PR TITLE
GGML ONNX Runtime

### DIFF
--- a/ggml/contrib/onnx.py
+++ b/ggml/contrib/onnx.py
@@ -1509,16 +1509,6 @@ class GgmlBackendRep(BackendRep):
 
         # Build layers
         for node in model_graph.node:
-            # print(
-            #     "OP:",
-            #     node.op_type,
-            #     "| NODE:",
-            #     node.name,
-            #     "| IN:",
-            #     node.input,
-            #     "| OUT:",
-            #     node.output[0],
-            # )
             node_output = ggml_operators[node.op_type](
                 self,
                 node,
@@ -1526,10 +1516,6 @@ class GgmlBackendRep(BackendRep):
                 context,
                 refs,
             )
-
-            node_value = ggml.utils.to_numpy(self.eval_tensor(node_output, context))
-            # print("OUTPUT_SHAPE:", node_value.shape)
-            # print()
 
             if node.output[-1] == self.graph.output[-1].name:
                 exit_node = node_output

--- a/ggml/contrib/onnx.py
+++ b/ggml/contrib/onnx.py
@@ -356,15 +356,14 @@ def ggml_operator_constant(
     value_attr = next(attr for attr in node_attributes if attr.name == "value")
     tensor = value_attr.t
     data_type = tensor.data_type
+
     np_data_type = tensor_dtype_to_np_dtype(data_type)
     np_data_type_limit = np.dtype(str(np_data_type).replace("64", "32"))
 
     if tensor.raw_data:
         data_value = np.frombuffer(tensor.raw_data, dtype=np_data_type)
-    elif tensor.float_data:
-        data_value = np.array(tensor.float_data, dtype=np_data_type)
     else:
-        raise ValueError("Data field not found.")
+        data_value = onnx.numpy_helper.to_array(tensor)
 
     data_tensor = ggml.utils.from_numpy(
         data_value.astype(np_data_type_limit),

--- a/ggml/ggml.py
+++ b/ggml/ggml.py
@@ -5962,6 +5962,95 @@ lib.ggml_internal_get_type_traits.restype = ggml_type_traits_t
 
 
 #####################################################
+# GGML ALLOC API
+# source: ggml-alloc.h
+#####################################################
+
+ggml_allocr_p = ctypes.c_void_p
+
+
+# GGML_API struct ggml_allocr * ggml_allocr_new(void * data, size_t size, size_t alignment);
+def ggml_allocr_new(
+    data: ctypes.c_void_p,
+    size: Union[ctypes.c_size_t, int],
+    alignment: Union[ctypes.c_size_t, int],
+) -> ggml_allocr_p:
+    return lib.ggml_allocr_new(data, size, alignment)
+
+
+lib.ggml_allocr_new.argtypes = [ctypes.c_void_p, ctypes.c_size_t, ctypes.c_size_t]
+lib.ggml_allocr_new.restype = ggml_allocr_p
+
+
+# GGML_API struct ggml_allocr * ggml_allocr_new_measure(size_t alignment);
+def ggml_allocr_new_measure(
+    alignment: Union[ctypes.c_size_t, int],
+) -> ggml_allocr_p:
+    return lib.ggml_allocr_new_measure(alignment)
+
+
+lib.ggml_allocr_new_measure.argtypes = [ctypes.c_size_t]
+lib.ggml_allocr_new_measure.restype = ggml_allocr_p
+
+
+# GGML_API void   ggml_allocr_free(struct ggml_allocr * alloc);
+def ggml_allocr_free(
+    alloc: ggml_allocr_p,
+):
+    return lib.ggml_allocr_free(alloc)
+
+
+lib.ggml_allocr_free.argtypes = [ggml_allocr_p]
+lib.ggml_allocr_free.restype = None
+
+
+# GGML_API bool   ggml_allocr_is_measure(struct ggml_allocr * alloc);
+def ggml_allocr_is_measure(
+    alloc: ggml_allocr_p,
+) -> bool:
+    return lib.ggml_allocr_is_measure(alloc)
+
+
+lib.ggml_allocr_is_measure.argtypes = [ggml_allocr_p]
+lib.ggml_allocr_is_measure.restype = ctypes.c_bool
+
+
+# GGML_API void   ggml_allocr_reset(struct ggml_allocr * alloc);
+def ggml_allocr_reset(
+    alloc: ggml_allocr_p,
+):
+    return lib.ggml_allocr_reset(alloc)
+
+
+lib.ggml_allocr_reset.argtypes = [ggml_allocr_p]
+lib.ggml_allocr_reset.restype = None
+
+
+# GGML_API void   ggml_allocr_alloc(struct ggml_allocr * alloc, struct ggml_tensor * tensor);
+def ggml_allocr_alloc(
+    alloc: ggml_allocr_p,
+    tensor: ggml_tensor_p,
+):
+    return lib.ggml_allocr_alloc(alloc, tensor)
+
+
+lib.ggml_allocr_alloc_graph.argtypes = [ggml_allocr_p, ctypes.POINTER(ggml_tensor)]
+lib.ggml_allocr_alloc.restype = None
+
+
+# GGML_API size_t ggml_allocr_alloc_graph(struct ggml_allocr * alloc, struct ggml_cgraph * graph);
+def ggml_allocr_alloc_graph(
+    alloc: ggml_allocr_p,
+    graph: ggml_cgraph_p,
+) -> int:
+    return lib.ggml_allocr_alloc_graph(alloc, graph)
+
+
+lib.ggml_allocr_alloc_graph.argtypes = [ggml_allocr_p, ctypes.POINTER(ggml_cgraph)]
+lib.ggml_allocr_alloc_graph.restype = ctypes.c_size_t
+
+
+#####################################################
 # GGML CUDA API
 # source: ggml-cuda.h
 #####################################################

--- a/ggml/ggml.py
+++ b/ggml/ggml.py
@@ -7228,7 +7228,7 @@ def ggml_allocr_alloc(
     return lib.ggml_allocr_alloc(alloc, tensor)
 
 
-lib.ggml_allocr_alloc_graph.argtypes = [ggml_allocr_p, ctypes.POINTER(ggml_tensor)]
+lib.ggml_allocr_alloc.argtypes = [ggml_allocr_p, ctypes.POINTER(ggml_tensor)]
 lib.ggml_allocr_alloc.restype = None
 
 

--- a/ggml/ggml.py
+++ b/ggml/ggml.py
@@ -110,8 +110,8 @@ lib = load_shared_library(module_name, lib_base_name)
 
 CFloatArray: TypeAlias = "ctypes.Array[ctypes.c_float]"
 CInt64Array: TypeAlias = "ctypes.Array[ctypes.c_int64]"
-CIntPointer: TypeAlias = "ctypes._Pointer[ctypes.c_int]" # type: ignore
-CCharPointer: TypeAlias = "ctypes._Pointer[ctypes.c_char]" # type: ignore
+CIntPointer: TypeAlias = "ctypes._Pointer[ctypes.c_int]"  # type: ignore
+CCharPointer: TypeAlias = "ctypes._Pointer[ctypes.c_char]"  # type: ignore
 
 
 #####################################################
@@ -952,8 +952,10 @@ def ggml_nbytes_pad(
         number of bytes"""
     return lib.ggml_nbytes_pad(tensor)
 
+
 lib.ggml_nbytes_pad.argtypes = [ctypes.POINTER(ggml_tensor)]
 lib.ggml_nbytes_pad.restype = ctypes.c_size_t
+
 
 # GGML_API size_t  ggml_nbytes_split(const struct ggml_tensor * tensor, int nrows_split);
 def ggml_nbytes_split(
@@ -2952,12 +2954,14 @@ def ggml_group_norm(
         Pointer to ggml_tensor"""
     return lib.ggml_group_norm(ctx, a, n_groups)
 
+
 lib.ggml_group_norm.argtypes = [
     ggml_context_p,
     ctypes.POINTER(ggml_tensor),
     ctypes.c_int,
 ]
 lib.ggml_group_norm.restype = ctypes.POINTER(ggml_tensor)
+
 
 # GGML_API struct ggml_tensor * ggml_group_norm_inplace(
 #         struct ggml_context * ctx,
@@ -2979,12 +2983,14 @@ def ggml_group_norm_inplace(
         Pointer to ggml_tensor"""
     return lib.ggml_group_norm_inplace(ctx, a, n_groups)
 
+
 lib.ggml_group_norm_inplace.argtypes = [
     ggml_context_p,
     ctypes.POINTER(ggml_tensor),
     ctypes.c_int,
 ]
 lib.ggml_group_norm_inplace.restype = ctypes.POINTER(ggml_tensor)
+
 
 # // a - x
 # // b - dy
@@ -6283,6 +6289,7 @@ lib.gguf_get_data.argtypes = [
 ]
 lib.gguf_get_data.restype = ctypes.c_void_p
 
+
 # GGML_API int          gguf_get_n_kv(struct gguf_context * ctx);
 def gguf_get_n_kv(
     ctx: gguf_context_p,
@@ -7403,16 +7410,42 @@ GGML_METAL_MAX_BUFFERS = ctypes.c_int(16)
 ggml_metal_context_p = ctypes.c_void_p
 
 
-# struct ggml_metal_context * ggml_metal_init(void);
-def ggml_metal_init() -> ggml_metal_context_p:
-    return lib.ggml_metal_init()
+# struct ggml_metal_context * ggml_metal_init(int n_cb);
+def ggml_metal_init(
+    n_cb: Union[ctypes.c_int, int],
+) -> ggml_metal_context_p:
+    return lib.ggml_metal_init(n_cb)
 
 
 if GGML_USE_METAL:
-    lib.ggml_metal_init.argtypes = []
+    lib.ggml_metal_init.argtypes = [ctypes.c_int]
     lib.ggml_metal_init.restype = ggml_metal_context_p
 
+
 # void ggml_metal_free(struct ggml_metal_context * ctx);
+def ggml_metal_free(
+    ctx: ggml_metal_context_p,
+):
+    return lib.ggml_metal_free(ctx)
+
+
+if GGML_USE_METAL:
+    lib.ggml_metal_free.argtypes = [ggml_metal_context_p]
+    lib.ggml_metal_free.restype = None
+
+
+# // set the number of command buffers to use
+# void ggml_metal_set_n_cb(struct ggml_metal_context * ctx, int n_cb);
+def ggml_metal_set_n_cb(
+    ctx: ggml_metal_context_p,
+    n_cb: Union[ctypes.c_int, int],
+):
+    return lib.ggml_metal_set_n_cb(ctx, n_cb)
+
+
+if GGML_USE_METAL:
+    lib.ggml_metal_set_n_cb.argtypes = [ggml_metal_context_p, ctypes.c_int]
+    lib.ggml_metal_set_n_cb.restype = None
 
 
 # // creates a mapping between a host memory buffer and a device memory buffer
@@ -7430,11 +7463,11 @@ if GGML_USE_METAL:
 #                            size_t   max_size);
 def ggml_metal_add_buffer(
     ctx: ggml_metal_context_p,
-    name: ctypes.c_char_p,
+    name: bytes,
     data: ctypes.c_void_p,
     size: Union[ctypes.c_size_t, int],
     max_size: Union[ctypes.c_size_t, int],
-) -> ctypes.c_bool:
+) -> bool:
     return lib.ggml_metal_add_buffer(ctx, name, data, size, max_size)
 
 
@@ -7447,6 +7480,23 @@ if GGML_USE_METAL:
         ctypes.c_size_t,
     ]
     lib.ggml_metal_add_buffer.restype = ctypes.c_bool
+
+
+# // set data from host memory into the device
+# void ggml_metal_set_tensor(struct ggml_metal_context * ctx, struct ggml_tensor * t);
+def ggml_metal_set_tensor(
+    ctx: ggml_metal_context_p,
+    t: ggml_tensor_p,
+):
+    return lib.ggml_metal_set_tensor(ctx, t)
+
+
+if GGML_USE_METAL:
+    lib.ggml_metal_set_tensor.argtypes = [
+        ggml_metal_context_p,
+        ctypes.POINTER(ggml_tensor),
+    ]
+    lib.ggml_metal_set_tensor.restype = None
 
 
 # // get data from the device into host memory
@@ -7464,6 +7514,56 @@ if GGML_USE_METAL:
         ctypes.POINTER(ggml_tensor),
     ]
     lib.ggml_metal_get_tensor.restype = None
+
+
+# // try to find operations that can be run concurrently in the graph
+# // you should run it again if the topology of your graph changes
+# void ggml_metal_graph_find_concurrency(struct ggml_metal_context * ctx, struct ggml_cgraph * gf, bool check_mem);
+def ggml_metal_graph_find_concurrency(
+    ctx: ggml_metal_context_p,
+    gf: ggml_cgraph_p,
+    check_mem: Union[ctypes.c_bool, bool],
+):
+    return lib.ggml_metal_graph_find_concurrency(ctx, gf, check_mem)
+
+
+if GGML_USE_METAL:
+    lib.ggml_metal_graph_find_concurrency.argtypes = [
+        ggml_metal_context_p,
+        ctypes.POINTER(ggml_cgraph),
+        ctypes.c_bool,
+    ]
+    lib.ggml_metal_graph_find_concurrency.restype = None
+
+
+# // if the graph has been optimized for concurrently dispatch, return length of the concur_list if optimized
+# int ggml_metal_if_optimized(struct ggml_metal_context * ctx);
+def ggml_metal_if_optimized(
+    ctx: ggml_metal_context_p,
+) -> int:
+    return lib.ggml_metal_if_optimized(ctx)
+
+
+if GGML_USE_METAL:
+    lib.ggml_metal_if_optimized.argtypes = [
+        ggml_metal_context_p,
+    ]
+    lib.ggml_metal_if_optimized.restype = ctypes.c_int
+
+
+# // output the concur_list for ggml_alloc
+# int * ggml_metal_get_concur_list(struct ggml_metal_context * ctx);
+def ggml_metal_get_concur_list(
+    ctx: ggml_metal_context_p,
+) -> CIntPointer:
+    return lib.ggml_metal_get_concur_list(ctx)
+
+
+if GGML_USE_METAL:
+    lib.ggml_metal_get_concur_list.argtypes = [
+        ggml_metal_context_p,
+    ]
+    lib.ggml_metal_get_concur_list.restype = CIntPointer
 
 
 # // same as ggml_graph_compute but uses Metal

--- a/ggml/utils.py
+++ b/ggml/utils.py
@@ -74,6 +74,9 @@ def from_numpy(x: npt.NDArray[Any], ctx: ggml.ggml_context_p) -> ggml.ggml_tenso
     Returns:
         New ggml tensor with data copied from x
     """
+    if x.dtype.type == np.bool_:
+        x = x.astype(np.int32)
+
     ggml_type = NUMPY_DTYPE_TO_GGML_TYPE[x.dtype.type]
     shape = tuple(reversed(x.shape))
     tensor = ggml.ggml_new_tensor(
@@ -264,12 +267,12 @@ def slice_tensor(
     """Slice a ggml tensor along multiple dimensions.
 
     The slice is a view of the original tensor with the same number of dimensions.
-    
+
     Parameters:
         ctx: ggml context
         tensor: ggml tensor
         indices: indices to slice along
-        
+
     Returns:
         New ggml tensor slice view"""
     ndims = get_ndims(tensor)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "ggml_python"
-version = "0.0.14"
+version = "0.0.15"
 description = "Python bindings for ggml"
 readme = "README.md"
 license = { text = "MIT" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "ggml_python"
-version = "0.0.12"
+version = "0.0.13"
 description = "Python bindings for ggml"
 readme = "README.md"
 license = { text = "MIT" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "ggml_python"
-version = "0.0.13"
+version = "0.0.14"
 description = "Python bindings for ggml"
 readme = "README.md"
 license = { text = "MIT" }
@@ -29,6 +29,9 @@ classifiers = [
 wheel.packages = ["ggml"]
 wheel.expand-macos-universal-tags = true
 cmake.verbose = true
+
+[tool.pytest.ini_options]
+addopts = "--ignore=vendor"
 
 [project.optional-dependencies]
 test = ["pytest"]

--- a/tests/test_ggml.py
+++ b/tests/test_ggml.py
@@ -1,5 +1,3 @@
-import pytest
-
 import ctypes
 from typing import Optional
 import ggml
@@ -114,7 +112,6 @@ def test_ggml_min_alloc():
     ggml.ggml_free(ctx)
 
 
-@pytest.mark.skip(reason="ggml_allocr_alloc causes segfault on some platforms")
 def test_ggml_alloc():
     def build_graph(ctx: ggml.ggml_context_p, alloc: ggml.ggml_allocr_p):
         # inputs
@@ -129,14 +126,11 @@ def test_ggml_alloc():
         ggml.ggml_allocr_alloc(alloc, b)
 
         x2 = ggml.ggml_mul(ctx, x, x)
-        ggml.ggml_allocr_alloc(alloc, x2)
         tmp = ggml.ggml_mul(ctx, a, x2)
-        ggml.ggml_allocr_alloc(alloc, tmp)
 
         # outputs
         f = ggml.ggml_add(ctx, tmp, b)
         ggml.ggml_set_name(f, b"f")
-        ggml.ggml_allocr_alloc(alloc, f)
 
         # build graph
         gf = ggml.ggml_build_forward(f)

--- a/tests/test_ggml.py
+++ b/tests/test_ggml.py
@@ -1,3 +1,5 @@
+import pytest
+
 import ctypes
 from typing import Optional
 import ggml
@@ -32,7 +34,13 @@ def test_ggml_custom_op():
     x_in = ggml.ggml_new_tensor_1d(ctx, ggml.GGML_TYPE_F32, 1)
 
     @ggml.ggml_custom1_op_t
-    def double(tensor_out: ggml.ggml_tensor_p, tensor_in: ggml.ggml_tensor_p, ith: int, nth: int, userdata: Optional[ctypes.c_void_p]):
+    def double(
+        tensor_out: ggml.ggml_tensor_p,
+        tensor_in: ggml.ggml_tensor_p,
+        ith: int,
+        nth: int,
+        userdata: Optional[ctypes.c_void_p],
+    ):
         value = ggml.ggml_get_f32_1d(tensor_in, 0)
         ggml.ggml_set_f32(tensor_out, 2 * value)
 
@@ -104,6 +112,88 @@ def test_ggml_min_alloc():
     output = ggml.ggml_get_f32_1d(f, 0)
     assert output == 16.0
     ggml.ggml_free(ctx)
+
+
+def test_ggml_alloc():
+    def build_graph(ctx: ggml.ggml_context_p, alloc: ggml.ggml_allocr_p):
+        # inputs
+        x = ggml.ggml_new_tensor_1d(ctx, ggml.GGML_TYPE_F32, 1)
+        ggml.ggml_set_name(x, b"x")
+        ggml.ggml_allocr_alloc(alloc, x)
+        a = ggml.ggml_new_tensor_1d(ctx, ggml.GGML_TYPE_F32, 1)
+        ggml.ggml_set_name(a, b"a")
+        ggml.ggml_allocr_alloc(alloc, a)
+        b = ggml.ggml_new_tensor_1d(ctx, ggml.GGML_TYPE_F32, 1)
+        ggml.ggml_set_name(b, b"b")
+        ggml.ggml_allocr_alloc(alloc, b)
+
+        x2 = ggml.ggml_mul(ctx, x, x)
+        ggml.ggml_allocr_alloc(alloc, x2)
+        tmp = ggml.ggml_mul(ctx, a, x2)
+        ggml.ggml_allocr_alloc(alloc, tmp)
+
+        # outputs
+        f = ggml.ggml_add(ctx, tmp, b)
+        ggml.ggml_set_name(f, b"f")
+        ggml.ggml_allocr_alloc(alloc, f)
+
+        # build graph
+        gf = ggml.ggml_build_forward(f)
+
+        return gf
+
+    overhead = ggml.ggml_tensor_overhead()
+    max_overhead = overhead * 2 * ggml.GGML_MAX_NODES
+    assert max_overhead < 16 * 1024 * 1024  # 16MB
+    params = ggml.ggml_init_params(
+        mem_size=max_overhead, mem_buffer=None, no_alloc=True
+    )
+    ctx = ggml.ggml_init(params=params)
+
+    tensor_alignment = 32
+    alloc = ggml.ggml_allocr_new_measure(tensor_alignment)
+    assert alloc is not None
+    assert ggml.ggml_allocr_is_measure(alloc)
+
+    gf = build_graph(ctx, alloc)
+    gp = ggml.ggml_graph_plan(ctypes.pointer(gf), 1)
+    assert gp.work_size == 0
+
+    alloc_size = (
+        ggml.ggml_allocr_alloc_graph(alloc, ctypes.pointer(gf)) + tensor_alignment
+    )
+
+    ggml.ggml_free(ctx)
+    ggml.ggml_allocr_free(alloc)
+
+    params = ggml.ggml_init_params(
+        mem_size=max_overhead, mem_buffer=None, no_alloc=True
+    )
+    ctx = ggml.ggml_init(params=params)
+    buffer = (ctypes.c_uint8 * alloc_size)()
+    alloc = ggml.ggml_allocr_new(
+        ctypes.cast(buffer, ctypes.c_void_p), alloc_size, tensor_alignment
+    )
+    gf = build_graph(ctx, alloc)
+    ggml.ggml_allocr_alloc_graph(alloc, ctypes.pointer(gf))
+
+    a = ggml.ggml_get_tensor(ctx, b"a")
+    b = ggml.ggml_get_tensor(ctx, b"b")
+    x = ggml.ggml_get_tensor(ctx, b"x")
+    f = ggml.ggml_get_tensor(ctx, b"f")
+
+    assert a is not None and b is not None and x is not None and f is not None
+
+    ggml.ggml_set_f32(x, 2.0)
+    ggml.ggml_set_f32(a, 3.0)
+    ggml.ggml_set_f32(b, 4.0)
+
+    gp = ggml.ggml_graph_plan(ctypes.pointer(gf), 1)
+    ggml.ggml_graph_compute(ctypes.pointer(gf), ctypes.pointer(gp))
+    output = ggml.ggml_get_f32_1d(f, 0)
+    assert output == 16.0
+    ggml.ggml_free(ctx)
+    ggml.ggml_allocr_free(alloc)
 
 
 def test_quantize():

--- a/tests/test_ggml.py
+++ b/tests/test_ggml.py
@@ -82,9 +82,9 @@ def test_ggml_min_alloc():
     gp = ggml.ggml_graph_plan(ctypes.pointer(gf), 1)
 
     n_nodes = gf.n_nodes
-    nodes_size = sum(ggml.ggml_nbytes(gf.nodes[i]) for i in range(n_nodes))
+    nodes_size = sum(ggml.ggml_nbytes_pad(gf.nodes[i]) for i in range(n_nodes))
     n_leafs = gf.n_leafs
-    leafs_size = sum(ggml.ggml_nbytes(gf.leafs[i]) for i in range(n_leafs))
+    leafs_size = sum(ggml.ggml_nbytes_pad(gf.leafs[i]) for i in range(n_leafs))
 
     ggml.ggml_free(ctx)
 
@@ -114,6 +114,7 @@ def test_ggml_min_alloc():
     ggml.ggml_free(ctx)
 
 
+@pytest.mark.skip(reason="ggml_allocr_alloc causes segfault on some platforms")
 def test_ggml_alloc():
     def build_graph(ctx: ggml.ggml_context_p, alloc: ggml.ggml_allocr_p):
         # inputs

--- a/tests/test_ggml_onnx.py
+++ b/tests/test_ggml_onnx.py
@@ -108,16 +108,14 @@ backend_test.include("test_div_")
 backend_test.exclude("test_div_uint8_")  # not supported
 
 backend_test.include("test_gather_")
-backend_test.exclude("test_gather_2d")
 backend_test.exclude("test_gather_elements")
-backend_test.exclude("test_gather_negative")
 
 backend_test.include("test_greater_")
 backend_test.exclude("test_greater_bcast")
+backend_test.exclude("test_greater_cuda")
 backend_test.exclude("test_greater_equal")
 
 backend_test.include("test_less_")
-backend_test.exclude("test_less_")
 backend_test.exclude("test_less_bcast")
 backend_test.exclude("test_less_cuda")
 backend_test.exclude("test_less_equal_")
@@ -180,12 +178,7 @@ backend_test.exclude("test_reshape_allowzero")
 backend_test.exclude("test_reshape_zero")
 
 backend_test.include("test_shape_")
-backend_test.exclude("test_shape_cpu")
 backend_test.exclude("test_shape_cuda")
-# backend_test.exclude("test_shape_clip")
-# backend_test.exclude("test_shape_start")
-# backend_test.exclude("test_shape_end")
-# backend_test.exclude("test_shape_example")
 
 backend_test.include("test_softmax_")
 backend_test.exclude("test_softmax_axis")
@@ -197,19 +190,15 @@ backend_test.exclude("test_softmax_functional")
 backend_test.exclude("test_softmax_lastdim")
 
 backend_test.include("test_sqrt_")
-# backend_test.exclude("test_sqrt_cpu")
 backend_test.exclude("test_sqrt_cuda")
-# backend_test.exclude("test_sqrt_example")
 
 backend_test.include("test_sub_")
-# backend_test.exclude("test_sub_cpu")
-# backend_test.exclude("test_sub_example")  # not supported
 backend_test.exclude("test_sub_cuda")  # not supported
 backend_test.exclude("test_sub_bcast_")  # not supported
 backend_test.exclude("test_sub_uint8_")  # not supported
 
 backend_test.include("test_transpose_")
-backend_test.exclude("test_transpose_")
+# backend_test.exclude("test_transpose_")
 
 backend_test.include("test_unsqueeze_")
 backend_test.exclude("test_unsqueeze_")
@@ -220,9 +209,6 @@ backend_test.exclude("test_where_example")
 
 backend_test.exclude(".*cuda.*")
 backend_test.exclude(".*pad.*")
-backend_test.exclude(
-    ".*greater.*"
-)  # FIXME: values are correct dtypes are not bool != int32
 backend_test.exclude(".*FLOAT*E*M*.*")
 
 # import all test cases at global scope to make them visible to python.unittest

--- a/tests/test_ggml_onnx.py
+++ b/tests/test_ggml_onnx.py
@@ -230,6 +230,9 @@ backend_test.exclude("test_where_example")
 
 backend_test.exclude(".*cuda.*")
 backend_test.exclude(".*pad.*")
+backend_test.exclude(
+    ".*greater.*"
+)  # FIXME: values are correct dtypes are not bool != int32
 
 # import all test cases at global scope to make them visible to python.unittest
 globals().update(backend_test.enable_report().test_cases)

--- a/tests/test_ggml_onnx.py
+++ b/tests/test_ggml_onnx.py
@@ -130,7 +130,7 @@ backend_test.exclude("test_max_int64")
 backend_test.exclude("test_max_uint")
 
 backend_test.include("test_min_")
-backend_test.exclude("test_min_float16")
+backend_test.exclude("test_min_float16")  # uint16 not supported
 backend_test.exclude("test_min_float64")
 backend_test.exclude("test_min_int64")
 backend_test.exclude("test_min_uint")

--- a/tests/test_ggml_onnx.py
+++ b/tests/test_ggml_onnx.py
@@ -198,14 +198,12 @@ backend_test.exclude("test_sub_bcast_")  # not supported
 backend_test.exclude("test_sub_uint8_")  # not supported
 
 backend_test.include("test_transpose_")
-# backend_test.exclude("test_transpose_")
 
 backend_test.include("test_unsqueeze_")
-backend_test.exclude("test_unsqueeze_")
+# backend_test.exclude("test_unsqueeze_")
 
 backend_test.include("test_where_")
 backend_test.exclude("test_where_long")
-backend_test.exclude("test_where_example")
 
 backend_test.exclude(".*cuda.*")
 backend_test.exclude(".*pad.*")

--- a/tests/test_ggml_onnx.py
+++ b/tests/test_ggml_onnx.py
@@ -111,12 +111,10 @@ backend_test.include("test_gather_")
 backend_test.exclude("test_gather_elements")
 
 backend_test.include("test_greater_")
-backend_test.exclude("test_greater_bcast")
 backend_test.exclude("test_greater_cuda")
 backend_test.exclude("test_greater_equal")
 
 backend_test.include("test_less_")
-backend_test.exclude("test_less_bcast")
 backend_test.exclude("test_less_cuda")
 backend_test.exclude("test_less_equal_")
 
@@ -126,38 +124,22 @@ backend_test.exclude("test_log_softmax_*")
 backend_test.include("test_matmul_")
 
 backend_test.include("test_max_")
-backend_test.exclude("test_max_one")
-backend_test.exclude("test_max_two")
-backend_test.exclude("test_max_float16")
-backend_test.exclude("test_max_float32")
+backend_test.exclude("test_max_float16")  # uint16 not supported
 backend_test.exclude("test_max_float64")
-backend_test.exclude("test_max_int8")
-backend_test.exclude("test_max_int16")
-backend_test.exclude("test_max_int32")
 backend_test.exclude("test_max_int64")
 backend_test.exclude("test_max_uint")
-backend_test.exclude("test_max_example")
 
 backend_test.include("test_min_")
-backend_test.exclude("test_min_one")
-backend_test.exclude("test_min_two")
 backend_test.exclude("test_min_float16")
-backend_test.exclude("test_min_float32")
 backend_test.exclude("test_min_float64")
-backend_test.exclude("test_min_int8")
-backend_test.exclude("test_min_int16")
-backend_test.exclude("test_min_int32")
 backend_test.exclude("test_min_int64")
 backend_test.exclude("test_min_uint")
-backend_test.exclude("test_min_example")
 
 backend_test.include("test_mul_")
 backend_test.exclude("test_mul_uint8")
 
 backend_test.include("test_pow_")
 backend_test.exclude("test_pow_bcast")
-backend_test.exclude("test_pow_types")
-backend_test.exclude("test_pow_types_int64")
 backend_test.exclude("test_pow_types_int64")
 
 backend_test.include("test_range_")
@@ -200,7 +182,7 @@ backend_test.exclude("test_sub_uint8_")  # not supported
 backend_test.include("test_transpose_")
 
 backend_test.include("test_unsqueeze_")
-# backend_test.exclude("test_unsqueeze_")
+backend_test.exclude("test_unsqueeze_")
 
 backend_test.include("test_where_")
 backend_test.exclude("test_where_long")

--- a/tests/test_ggml_onnx.py
+++ b/tests/test_ggml_onnx.py
@@ -95,7 +95,7 @@ backend_test = onnx.backend.test.BackendTest(GgmlRuntimeBackend, __name__)
 backend_test.include("test_abs_")
 
 backend_test.include("test_add_")
-backend_test.exclude("test_add_uint8_") # not supported
+backend_test.exclude("test_add_uint8_")  # not supported
 
 backend_test.include("test_cast_")
 
@@ -105,7 +105,7 @@ backend_test.include("test_constant_")
 
 backend_test.include("test_div_")
 
-backend_test.exclude("test_div_uint8_") # not supported
+backend_test.exclude("test_div_uint8_")  # not supported
 
 backend_test.include("test_gather_")
 backend_test.exclude("test_gather_2d")
@@ -213,10 +213,10 @@ backend_test.exclude("test_sqrt_example")
 
 backend_test.include("test_sub_")
 backend_test.exclude("test_sub_cpu")
-backend_test.exclude("test_sub_example") # not supported
-backend_test.exclude("test_sub_cuda") # not supported
-backend_test.exclude("test_sub_bcast_") # not supported
-backend_test.exclude("test_sub_uint8_") # not supported
+backend_test.exclude("test_sub_example")  # not supported
+backend_test.exclude("test_sub_cuda")  # not supported
+backend_test.exclude("test_sub_bcast_")  # not supported
+backend_test.exclude("test_sub_uint8_")  # not supported
 
 backend_test.include("test_transpose_")
 backend_test.exclude("test_transpose_")
@@ -229,6 +229,7 @@ backend_test.exclude("test_where_long")
 backend_test.exclude("test_where_example")
 
 backend_test.exclude(".*cuda.*")
+backend_test.exclude(".*pad.*")
 
 # import all test cases at global scope to make them visible to python.unittest
 globals().update(backend_test.enable_report().test_cases)

--- a/tests/test_ggml_onnx.py
+++ b/tests/test_ggml_onnx.py
@@ -123,10 +123,9 @@ backend_test.exclude("test_less_cuda")
 backend_test.exclude("test_less_equal_")
 
 backend_test.include("test_log_")
-backend_test.exclude("test_log_")
+backend_test.exclude("test_log_softmax_*")
 
 backend_test.include("test_matmul_")
-backend_test.exclude("test_matmul_")
 
 backend_test.include("test_max_")
 backend_test.exclude("test_max_one")
@@ -155,13 +154,10 @@ backend_test.exclude("test_min_uint")
 backend_test.exclude("test_min_example")
 
 backend_test.include("test_mul_")
-backend_test.exclude("test_mul_")
-backend_test.exclude("test_mul_bcast")
-backend_test.exclude("test_mul_example")
 backend_test.exclude("test_mul_uint8")
 
 backend_test.include("test_pow_")
-backend_test.exclude("test_pow_")
+backend_test.exclude("test_pow_bcast")
 backend_test.exclude("test_pow_types")
 backend_test.exclude("test_pow_types_int64")
 backend_test.exclude("test_pow_types_int64")
@@ -177,25 +173,19 @@ backend_test.exclude("test_reduce_mean_keepdims")
 backend_test.exclude("test_reduce_mean_negative_axes")
 
 backend_test.include("test_relu_")
-backend_test.exclude("test_relu_")
 backend_test.exclude("test_relu_expanded")
 
 backend_test.include("test_reshape_")
 backend_test.exclude("test_reshape_allowzero")
-backend_test.exclude("test_reshape_negative")
-backend_test.exclude("test_reshape_one_dim")
-backend_test.exclude("test_reshape_reduced")
-backend_test.exclude("test_reshape_reordered")
 backend_test.exclude("test_reshape_zero")
-backend_test.exclude("test_reshape_extended")
 
 backend_test.include("test_shape_")
 backend_test.exclude("test_shape_cpu")
 backend_test.exclude("test_shape_cuda")
-backend_test.exclude("test_shape_clip")
-backend_test.exclude("test_shape_start")
-backend_test.exclude("test_shape_end")
-backend_test.exclude("test_shape_example")
+# backend_test.exclude("test_shape_clip")
+# backend_test.exclude("test_shape_start")
+# backend_test.exclude("test_shape_end")
+# backend_test.exclude("test_shape_example")
 
 backend_test.include("test_softmax_")
 backend_test.exclude("test_softmax_axis")
@@ -207,13 +197,13 @@ backend_test.exclude("test_softmax_functional")
 backend_test.exclude("test_softmax_lastdim")
 
 backend_test.include("test_sqrt_")
-backend_test.exclude("test_sqrt_cpu")
+# backend_test.exclude("test_sqrt_cpu")
 backend_test.exclude("test_sqrt_cuda")
-backend_test.exclude("test_sqrt_example")
+# backend_test.exclude("test_sqrt_example")
 
 backend_test.include("test_sub_")
-backend_test.exclude("test_sub_cpu")
-backend_test.exclude("test_sub_example")  # not supported
+# backend_test.exclude("test_sub_cpu")
+# backend_test.exclude("test_sub_example")  # not supported
 backend_test.exclude("test_sub_cuda")  # not supported
 backend_test.exclude("test_sub_bcast_")  # not supported
 backend_test.exclude("test_sub_uint8_")  # not supported
@@ -233,6 +223,7 @@ backend_test.exclude(".*pad.*")
 backend_test.exclude(
     ".*greater.*"
 )  # FIXME: values are correct dtypes are not bool != int32
+backend_test.exclude(".*FLOAT*E*M*.*")
 
 # import all test cases at global scope to make them visible to python.unittest
 globals().update(backend_test.enable_report().test_cases)

--- a/tests/test_ggml_onnx.py
+++ b/tests/test_ggml_onnx.py
@@ -147,10 +147,6 @@ backend_test.exclude("test_range_float")
 backend_test.exclude("test_range_int32")
 
 backend_test.include("test_reduce_mean_")
-backend_test.exclude("test_reduce_mean_default")
-backend_test.exclude("test_reduce_mean_do_not_keepdims")
-backend_test.exclude("test_reduce_mean_keepdims")
-backend_test.exclude("test_reduce_mean_negative_axes")
 
 backend_test.include("test_relu_")
 backend_test.exclude("test_relu_expanded")

--- a/tests/test_ggml_onnx_ops.py
+++ b/tests/test_ggml_onnx_ops.py
@@ -70,7 +70,19 @@ def test_ggml_onnx_runtime_shape_operator():
 
     for shape_node in nodes:
         output_tensor = ggml_operators["Shape"](
-            GgmlBackendRep(), shape_node, tensors_dict, context, refs
+            GgmlBackendRep(
+                graph=None,
+                weights=None,
+                weights_buffer=None,
+                inputs=None,
+                outputs=None,
+                ggml_context=None,
+                ggml_init_params=None,
+            ),
+            shape_node,
+            tensors_dict,
+            context,
+            refs,
         )
         gf = ggml.ggml_build_forward(output_tensor)
         ggml.ggml_graph_compute_with_ctx(context, ctypes.pointer(gf), 1)
@@ -164,12 +176,36 @@ def test_ggml_onnx_runtime_unsqueeze_operator():
 
     with pytest.raises(ValueError) as ex_input_error:
         ggml_operators["Unsqueeze"](
-            GgmlBackendRep(), unsqueeze_node1, tensors_dict, context, refs
+            GgmlBackendRep(
+                graph=None,
+                weights=None,
+                weights_buffer=None,
+                inputs=None,
+                outputs=None,
+                ggml_context=None,
+                ggml_init_params=None,
+            ),
+            unsqueeze_node1,
+            tensors_dict,
+            context,
+            refs,
         )
 
     for shape_node in nodes:
         output_tensor = ggml_operators["Unsqueeze"](
-            GgmlBackendRep(), shape_node, tensors_dict, context, refs
+            GgmlBackendRep(
+                graph=None,
+                weights=None,
+                weights_buffer=None,
+                inputs=None,
+                outputs=None,
+                ggml_context=None,
+                ggml_init_params=None,
+            ),
+            shape_node,
+            tensors_dict,
+            context,
+            refs,
         )
 
         gf = ggml.ggml_build_forward(output_tensor)
@@ -281,7 +317,19 @@ def test_ggml_onnx_runtime_gather_operator():
     refs = []
 
     output_tensor = ggml_operators["Gather"](
-        GgmlBackendRep(), gather_node2, tensors_dict, context, refs
+        GgmlBackendRep(
+            graph=None,
+            weights=None,
+            weights_buffer=None,
+            inputs=None,
+            outputs=None,
+            ggml_context=None,
+            ggml_init_params=None,
+        ),
+        gather_node2,
+        tensors_dict,
+        context,
+        refs,
     )
 
     gf = ggml.ggml_build_forward(output_tensor)
@@ -368,7 +416,19 @@ def test_ggml_onnx_constant_operator():
 
     for shape_node in nodes:
         output_tensor = ggml_operators["Constant"](
-            GgmlBackendRep(), shape_node, tensors_dict, context, refs
+            GgmlBackendRep(
+                graph=None,
+                weights=None,
+                weights_buffer=None,
+                inputs=None,
+                outputs=None,
+                ggml_context=None,
+                ggml_init_params=None,
+            ),
+            shape_node,
+            tensors_dict,
+            context,
+            refs,
         )
         gf = ggml.ggml_build_forward(output_tensor)
         ggml.ggml_graph_compute_with_ctx(context, ctypes.pointer(gf), 1)
@@ -446,7 +506,19 @@ def test_ggml_onnx_constant_of_shape_operator():
 
     for shape_node in nodes:
         output_tensor = ggml_operators["ConstantOfShape"](
-            GgmlBackendRep(), shape_node, tensors_dict, context, refs
+            GgmlBackendRep(
+                graph=None,
+                weights=None,
+                weights_buffer=None,
+                inputs=None,
+                outputs=None,
+                ggml_context=None,
+                ggml_init_params=None,
+            ),
+            shape_node,
+            tensors_dict,
+            context,
+            refs,
         )
         gf = ggml.ggml_build_forward(output_tensor)
         ggml.ggml_graph_compute_with_ctx(context, ctypes.pointer(gf), 1)
@@ -557,7 +629,19 @@ def test_ggml_onnx_concat_operator():
 
     for concat_node in nodes:
         output_tensor = ggml_operators["Concat"](
-            GgmlBackendRep(), concat_node, tensors_dict, context, refs
+            GgmlBackendRep(
+                graph=None,
+                weights=None,
+                weights_buffer=None,
+                inputs=None,
+                outputs=None,
+                ggml_context=None,
+                ggml_init_params=None,
+            ),
+            concat_node,
+            tensors_dict,
+            context,
+            refs,
         )
         gf = ggml.ggml_build_forward(output_tensor)
         ggml.ggml_graph_compute_with_ctx(context, ctypes.pointer(gf), 1)
@@ -632,7 +716,19 @@ def test_ggml_onnx_reshape_operation():
 
     for reshape_node in nodes:
         output_tensor = ggml_operators["Reshape"](
-            GgmlBackendRep(), reshape_node, tensors_dict, context, refs
+            GgmlBackendRep(
+                graph=None,
+                weights=None,
+                weights_buffer=None,
+                inputs=None,
+                outputs=None,
+                ggml_context=None,
+                ggml_init_params=None,
+            ),
+            reshape_node,
+            tensors_dict,
+            context,
+            refs,
         )
         gf = ggml.ggml_build_forward(output_tensor)
         ggml.ggml_graph_compute_with_ctx(context, ctypes.pointer(gf), 1)
@@ -757,7 +853,19 @@ def test_ggml_onnx_reducemean_operator():
 
     for reducemean_node in nodes:
         output_tensor = ggml_operators["ReduceMean"](
-            GgmlBackendRep(), reducemean_node, tensors_dict, context, refs
+            GgmlBackendRep(
+                graph=None,
+                weights=None,
+                weights_buffer=None,
+                inputs=None,
+                outputs=None,
+                ggml_context=None,
+                ggml_init_params=None,
+            ),
+            reducemean_node,
+            tensors_dict,
+            context,
+            refs,
         )
         gf = ggml.ggml_build_forward(output_tensor)
         ggml.ggml_graph_compute_with_ctx(context, ctypes.pointer(gf), 1)
@@ -829,7 +937,19 @@ def test_ggml_onnx_less_operator():
 
     for less_node in nodes:
         output_tensor = ggml_operators["Less"](
-            GgmlBackendRep(), less_node, tensors_dict, context, refs
+            GgmlBackendRep(
+                graph=None,
+                weights=None,
+                weights_buffer=None,
+                inputs=None,
+                outputs=None,
+                ggml_context=None,
+                ggml_init_params=None,
+            ),
+            less_node,
+            tensors_dict,
+            context,
+            refs,
         )
         gf = ggml.ggml_build_forward(output_tensor)
         ggml.ggml_graph_compute_with_ctx(context, ctypes.pointer(gf), 1)
@@ -896,7 +1016,19 @@ def test_ggml_onnx_greater_operator():
     )
 
     output_tensor = ggml_operators["Greater"](
-        GgmlBackendRep(), greater_node, tensors_dict, context, refs
+        GgmlBackendRep(
+            graph=None,
+            weights=None,
+            weights_buffer=None,
+            inputs=None,
+            outputs=None,
+            ggml_context=None,
+            ggml_init_params=None,
+        ),
+        greater_node,
+        tensors_dict,
+        context,
+        refs,
     )
     gf = ggml.ggml_build_forward(output_tensor)
     ggml.ggml_graph_compute_with_ctx(context, ctypes.pointer(gf), 1)
@@ -959,7 +1091,19 @@ def test_ggml_onnx_min_operator():
     )
 
     output_tensor = ggml_operators["Min"](
-        GgmlBackendRep(), min_node, tensors_dict, context, refs
+        GgmlBackendRep(
+            graph=None,
+            weights=None,
+            weights_buffer=None,
+            inputs=None,
+            outputs=None,
+            ggml_context=None,
+            ggml_init_params=None,
+        ),
+        min_node,
+        tensors_dict,
+        context,
+        refs,
     )
     gf = ggml.ggml_build_forward(output_tensor)
     ggml.ggml_graph_compute_with_ctx(context, ctypes.pointer(gf), 1)
@@ -1020,7 +1164,19 @@ def test_ggml_onnx_max_operator():
     )
 
     output_tensor = ggml_operators["Max"](
-        GgmlBackendRep(), min_node, tensors_dict, context, refs
+        GgmlBackendRep(
+            graph=None,
+            weights=None,
+            weights_buffer=None,
+            inputs=None,
+            outputs=None,
+            ggml_context=None,
+            ggml_init_params=None,
+        ),
+        min_node,
+        tensors_dict,
+        context,
+        refs,
     )
     gf = ggml.ggml_build_forward(output_tensor)
     ggml.ggml_graph_compute_with_ctx(context, ctypes.pointer(gf), 1)
@@ -1095,7 +1251,19 @@ def test_ggml_onnx_matmul_operator():
     )
 
     output_tensor = ggml_operators["MatMul"](
-        GgmlBackendRep(), matmul_node, tensors_dict, context, refs
+        GgmlBackendRep(
+            graph=None,
+            weights=None,
+            weights_buffer=None,
+            inputs=None,
+            outputs=None,
+            ggml_context=None,
+            ggml_init_params=None,
+        ),
+        matmul_node,
+        tensors_dict,
+        context,
+        refs,
     )
     gf = ggml.ggml_build_forward(output_tensor)
     ggml.ggml_graph_compute_with_ctx(context, ctypes.pointer(gf), 1)
@@ -1166,7 +1334,19 @@ def test_ggml_onnx_pow_operator():
 
     for pow_node in nodes:
         output_tensor = ggml_operators["Pow"](
-            GgmlBackendRep(), pow_node, tensors_dict, context, refs
+            GgmlBackendRep(
+                graph=None,
+                weights=None,
+                weights_buffer=None,
+                inputs=None,
+                outputs=None,
+                ggml_context=None,
+                ggml_init_params=None,
+            ),
+            pow_node,
+            tensors_dict,
+            context,
+            refs,
         )
         gf = ggml.ggml_build_forward(output_tensor)
         ggml.ggml_graph_compute_with_ctx(context, ctypes.pointer(gf), 1)
@@ -1233,7 +1413,19 @@ def test_ggml_onnx_relu_operator():
 
     for relu_node in nodes:
         output_tensor = ggml_operators["Relu"](
-            GgmlBackendRep(), relu_node, tensors_dict, context, refs
+            GgmlBackendRep(
+                graph=None,
+                weights=None,
+                weights_buffer=None,
+                inputs=None,
+                outputs=None,
+                ggml_context=None,
+                ggml_init_params=None,
+            ),
+            relu_node,
+            tensors_dict,
+            context,
+            refs,
         )
         gf = ggml.ggml_build_forward(output_tensor)
         ggml.ggml_graph_compute_with_ctx(context, ctypes.pointer(gf), 1)
@@ -1308,7 +1500,19 @@ def test_ggml_onnx_transpose_operator():
         onnx_result = onnx_transpose(input_array, permutation)
 
         output_tensor = ggml_operators["Transpose"](
-            GgmlBackendRep(), transpose_node, tensors_dict, context, refs
+            GgmlBackendRep(
+                graph=None,
+                weights=None,
+                weights_buffer=None,
+                inputs=None,
+                outputs=None,
+                ggml_context=None,
+                ggml_init_params=None,
+            ),
+            transpose_node,
+            tensors_dict,
+            context,
+            refs,
         )
         gf = ggml.ggml_build_forward(output_tensor)
         ggml.ggml_graph_compute_with_ctx(context, ctypes.pointer(gf), 1)
@@ -1397,7 +1601,19 @@ def test_ggml_onnx_range_operator():
     )
 
     output_tensor = ggml_operators["Range"](
-        GgmlBackendRep(), range_node, tensors_dict, context, refs
+        GgmlBackendRep(
+            graph=None,
+            weights=None,
+            weights_buffer=None,
+            inputs=None,
+            outputs=None,
+            ggml_context=None,
+            ggml_init_params=None,
+        ),
+        range_node,
+        tensors_dict,
+        context,
+        refs,
     )
     gf = ggml.ggml_build_forward(output_tensor)
     ggml.ggml_graph_compute_with_ctx(context, ctypes.pointer(gf), 1)
@@ -1460,7 +1676,19 @@ def test_ggml_onnx_cast_operator():
     )
 
     output_tensor = ggml_operators["Cast"](
-        GgmlBackendRep(), cast_node, tensors_dict, context, refs
+        GgmlBackendRep(
+            graph=None,
+            weights=None,
+            weights_buffer=None,
+            inputs=None,
+            outputs=None,
+            ggml_context=None,
+            ggml_init_params=None,
+        ),
+        cast_node,
+        tensors_dict,
+        context,
+        refs,
     )
     gf = ggml.ggml_build_forward(output_tensor)
     ggml.ggml_graph_compute_with_ctx(context, ctypes.pointer(gf), 1)
@@ -1534,7 +1762,19 @@ def test_ggml_onnx_where_operator():
     )
 
     output_tensor = ggml_operators["Where"](
-        GgmlBackendRep(), where_node, tensors_dict, context, refs
+        GgmlBackendRep(
+            graph=None,
+            weights=None,
+            weights_buffer=None,
+            inputs=None,
+            outputs=None,
+            ggml_context=None,
+            ggml_init_params=None,
+        ),
+        where_node,
+        tensors_dict,
+        context,
+        refs,
     )
     gf = ggml.ggml_build_forward(output_tensor)
     ggml.ggml_graph_compute_with_ctx(context, ctypes.pointer(gf), 1)

--- a/tests/test_ggml_onnx_ops.py
+++ b/tests/test_ggml_onnx_ops.py
@@ -1399,6 +1399,79 @@ def test_ggml_onnx_range_operator():
     ggml.ggml_free(context)
 
 
+def test_ggml_onnx_pow_operator():
+    # return
+
+    def onnx_pow(input, exponent):
+        pow_node = onnx.helper.make_node(
+            "Pow",
+            inputs=["input", "exponent"],
+            outputs=["output"],
+        )
+
+        graph = onnx.helper.make_graph(
+            [pow_node],
+            "pow_graph",
+            inputs=[
+                onnx.helper.make_tensor_value_info(
+                    "input", onnx.TensorProto.FLOAT, list(input.shape)
+                ),
+                onnx.helper.make_tensor_value_info(
+                    "exponent", onnx.TensorProto.FLOAT, list(exponent.shape)
+                ),
+            ],
+            outputs=[
+                onnx.helper.make_tensor_value_info(
+                    "output", onnx.TensorProto.FLOAT, list(input.shape)
+                ),
+            ],
+        )
+
+        model = onnx.helper.make_model(graph)
+
+        f = BytesIO()
+        onnx.save_model(model, f)
+
+        onnx_model_bytes = BytesIO(f.getvalue())
+
+        onnx_model_bytes.seek(0)
+        sess = ort.InferenceSession(onnx_model_bytes.read())
+
+        input_feed = {"input": input, "exponent": exponent}
+
+        output = sess.run(None, input_feed)
+
+        return output[0]
+
+    params = ggml.ggml_init_params(mem_size=16 * 1024 * 1024, mem_buffer=None)
+    context = ggml.ggml_init(params=params)
+    tensors_dict = {}
+    refs = []
+
+    input_array = np.array([2, 3, 4], np.float32)
+    exponent_array = np.array([3, 2, 1], np.float32)
+
+    pow_numpy = onnx_pow(input_array, exponent_array)
+
+    tensors_dict["input_array"] = ggml.utils.from_numpy(input_array, context)
+    tensors_dict["exponent_array"] = ggml.utils.from_numpy(exponent_array, context)
+
+    pow_node = onnx.helper.make_node(
+        "Pow",
+        inputs=["input_array", "exponent_array"],
+        outputs=["pow_output"],
+    )
+
+    output_tensor = ggml_operators["Pow"](pow_node, tensors_dict, context, refs)
+    gf = ggml.ggml_build_forward(output_tensor)
+    ggml.ggml_graph_compute_with_ctx(context, ctypes.pointer(gf), 1)
+    result = ggml.utils.to_numpy(output_tensor)
+
+    assert np.allclose(result, pow_numpy)
+
+    ggml.ggml_free(context)
+
+
 def test_ggml_onnx_cast_operator():
     # return
 

--- a/tests/test_ggml_onnx_ops.py
+++ b/tests/test_ggml_onnx_ops.py
@@ -16,7 +16,7 @@ from onnxruntime import InferenceSession
 import contextlib
 import ggml
 import ggml.utils
-from ggml.contrib.onnx import GgmlRuntimeBackend, ggml_operators
+from ggml.contrib.onnx import GgmlRuntimeBackend, ggml_operators, GgmlBackendRep
 
 
 def test_ggml_onnx_runtime_shape_operator():
@@ -69,7 +69,9 @@ def test_ggml_onnx_runtime_shape_operator():
     refs = []
 
     for shape_node in nodes:
-        output_tensor = ggml_operators["Shape"](shape_node, tensors_dict, context, refs)
+        output_tensor = ggml_operators["Shape"](
+            GgmlBackendRep(), shape_node, tensors_dict, context, refs
+        )
         gf = ggml.ggml_build_forward(output_tensor)
         ggml.ggml_graph_compute_with_ctx(context, ctypes.pointer(gf), 1)
         results.append(ggml.utils.to_numpy(output_tensor))
@@ -161,11 +163,13 @@ def test_ggml_onnx_runtime_unsqueeze_operator():
     results = []
 
     with pytest.raises(ValueError) as ex_input_error:
-        ggml_operators["Unsqueeze"](unsqueeze_node1, tensors_dict, context, refs)
+        ggml_operators["Unsqueeze"](
+            GgmlBackendRep(), unsqueeze_node1, tensors_dict, context, refs
+        )
 
     for shape_node in nodes:
         output_tensor = ggml_operators["Unsqueeze"](
-            shape_node, tensors_dict, context, refs
+            GgmlBackendRep(), shape_node, tensors_dict, context, refs
         )
 
         gf = ggml.ggml_build_forward(output_tensor)
@@ -276,7 +280,9 @@ def test_ggml_onnx_runtime_gather_operator():
 
     refs = []
 
-    output_tensor = ggml_operators["Gather"](gather_node2, tensors_dict, context, refs)
+    output_tensor = ggml_operators["Gather"](
+        GgmlBackendRep(), gather_node2, tensors_dict, context, refs
+    )
 
     gf = ggml.ggml_build_forward(output_tensor)
 
@@ -362,7 +368,7 @@ def test_ggml_onnx_constant_operator():
 
     for shape_node in nodes:
         output_tensor = ggml_operators["Constant"](
-            shape_node, tensors_dict, context, refs
+            GgmlBackendRep(), shape_node, tensors_dict, context, refs
         )
         gf = ggml.ggml_build_forward(output_tensor)
         ggml.ggml_graph_compute_with_ctx(context, ctypes.pointer(gf), 1)
@@ -440,7 +446,7 @@ def test_ggml_onnx_constant_of_shape_operator():
 
     for shape_node in nodes:
         output_tensor = ggml_operators["ConstantOfShape"](
-            shape_node, tensors_dict, context, refs
+            GgmlBackendRep(), shape_node, tensors_dict, context, refs
         )
         gf = ggml.ggml_build_forward(output_tensor)
         ggml.ggml_graph_compute_with_ctx(context, ctypes.pointer(gf), 1)
@@ -451,7 +457,7 @@ def test_ggml_onnx_constant_of_shape_operator():
 
 
 def test_ggml_onnx_concat_operator():
-    return
+    # return
 
     def onnx_concat(inputs, axis):
         input_data_type = inputs[0].dtype
@@ -551,7 +557,7 @@ def test_ggml_onnx_concat_operator():
 
     for concat_node in nodes:
         output_tensor = ggml_operators["Concat"](
-            concat_node, tensors_dict, context, refs
+            GgmlBackendRep(), concat_node, tensors_dict, context, refs
         )
         gf = ggml.ggml_build_forward(output_tensor)
         ggml.ggml_graph_compute_with_ctx(context, ctypes.pointer(gf), 1)
@@ -626,7 +632,7 @@ def test_ggml_onnx_reshape_operation():
 
     for reshape_node in nodes:
         output_tensor = ggml_operators["Reshape"](
-            reshape_node, tensors_dict, context, refs
+            GgmlBackendRep(), reshape_node, tensors_dict, context, refs
         )
         gf = ggml.ggml_build_forward(output_tensor)
         ggml.ggml_graph_compute_with_ctx(context, ctypes.pointer(gf), 1)
@@ -751,7 +757,7 @@ def test_ggml_onnx_reducemean_operator():
 
     for reducemean_node in nodes:
         output_tensor = ggml_operators["ReduceMean"](
-            reducemean_node, tensors_dict, context, refs
+            GgmlBackendRep(), reducemean_node, tensors_dict, context, refs
         )
         gf = ggml.ggml_build_forward(output_tensor)
         ggml.ggml_graph_compute_with_ctx(context, ctypes.pointer(gf), 1)
@@ -822,7 +828,9 @@ def test_ggml_onnx_less_operator():
     results = []
 
     for less_node in nodes:
-        output_tensor = ggml_operators["Less"](less_node, tensors_dict, context, refs)
+        output_tensor = ggml_operators["Less"](
+            GgmlBackendRep(), less_node, tensors_dict, context, refs
+        )
         gf = ggml.ggml_build_forward(output_tensor)
         ggml.ggml_graph_compute_with_ctx(context, ctypes.pointer(gf), 1)
         results.append(ggml.utils.to_numpy(output_tensor))
@@ -887,7 +895,9 @@ def test_ggml_onnx_greater_operator():
         outputs=["greater_output"],
     )
 
-    output_tensor = ggml_operators["Greater"](greater_node, tensors_dict, context, refs)
+    output_tensor = ggml_operators["Greater"](
+        GgmlBackendRep(), greater_node, tensors_dict, context, refs
+    )
     gf = ggml.ggml_build_forward(output_tensor)
     ggml.ggml_graph_compute_with_ctx(context, ctypes.pointer(gf), 1)
     result = ggml.utils.to_numpy(output_tensor)
@@ -948,7 +958,9 @@ def test_ggml_onnx_min_operator():
         outputs=["min_output"],
     )
 
-    output_tensor = ggml_operators["Min"](min_node, tensors_dict, context, refs)
+    output_tensor = ggml_operators["Min"](
+        GgmlBackendRep(), min_node, tensors_dict, context, refs
+    )
     gf = ggml.ggml_build_forward(output_tensor)
     ggml.ggml_graph_compute_with_ctx(context, ctypes.pointer(gf), 1)
     result = ggml.utils.to_numpy(output_tensor)
@@ -1007,7 +1019,9 @@ def test_ggml_onnx_max_operator():
         outputs=["min_output"],
     )
 
-    output_tensor = ggml_operators["Max"](min_node, tensors_dict, context, refs)
+    output_tensor = ggml_operators["Max"](
+        GgmlBackendRep(), min_node, tensors_dict, context, refs
+    )
     gf = ggml.ggml_build_forward(output_tensor)
     ggml.ggml_graph_compute_with_ctx(context, ctypes.pointer(gf), 1)
     result = ggml.utils.to_numpy(output_tensor)
@@ -1080,7 +1094,9 @@ def test_ggml_onnx_matmul_operator():
         outputs=["matmul_output"],
     )
 
-    output_tensor = ggml_operators["MatMul"](matmul_node, tensors_dict, context, refs)
+    output_tensor = ggml_operators["MatMul"](
+        GgmlBackendRep(), matmul_node, tensors_dict, context, refs
+    )
     gf = ggml.ggml_build_forward(output_tensor)
     ggml.ggml_graph_compute_with_ctx(context, ctypes.pointer(gf), 1)
     result = ggml.utils.to_numpy(output_tensor)
@@ -1149,7 +1165,9 @@ def test_ggml_onnx_pow_operator():
     results = []
 
     for pow_node in nodes:
-        output_tensor = ggml_operators["Pow"](pow_node, tensors_dict, context, refs)
+        output_tensor = ggml_operators["Pow"](
+            GgmlBackendRep(), pow_node, tensors_dict, context, refs
+        )
         gf = ggml.ggml_build_forward(output_tensor)
         ggml.ggml_graph_compute_with_ctx(context, ctypes.pointer(gf), 1)
         results.append(ggml.utils.to_numpy(output_tensor))
@@ -1214,7 +1232,9 @@ def test_ggml_onnx_relu_operator():
     results = []
 
     for relu_node in nodes:
-        output_tensor = ggml_operators["Relu"](relu_node, tensors_dict, context, refs)
+        output_tensor = ggml_operators["Relu"](
+            GgmlBackendRep(), relu_node, tensors_dict, context, refs
+        )
         gf = ggml.ggml_build_forward(output_tensor)
         ggml.ggml_graph_compute_with_ctx(context, ctypes.pointer(gf), 1)
         results.append(ggml.utils.to_numpy(output_tensor))
@@ -1237,12 +1257,12 @@ def test_ggml_onnx_transpose_operator():
             "transpose_graph",
             inputs=[
                 onnx.helper.make_tensor_value_info(
-                    "input", onnx.TensorProto.FLOAT, list(x.shape)
+                    "input", onnx.TensorProto.INT32, list(x.shape)
                 )
             ],
             outputs=[
                 onnx.helper.make_tensor_value_info(
-                    "output", onnx.TensorProto.FLOAT, list(x.shape)
+                    "output", onnx.TensorProto.INT32, [list(x.shape)[i] for i in perm]
                 )
             ],
         )
@@ -1270,14 +1290,13 @@ def test_ggml_onnx_transpose_operator():
 
     import itertools
 
-    input_array = np.random.rand(3, 3, 3).astype(np.float32)
+    shape = (2, 3, 4)
+    input_array = np.arange(np.prod(shape), dtype=np.int32).reshape(shape)
     permutations = list(itertools.permutations(np.arange(len(input_array.shape))))
 
     tensors_dict["input_array"] = ggml.utils.from_numpy(input_array, context)
-    nodes = []
-    ggml_results = []
-    onnx_results = []
-
+    print()
+    print()
     for i, permutation in enumerate(permutations):
         transpose_node = onnx.helper.make_node(
             "Transpose",
@@ -1286,32 +1305,24 @@ def test_ggml_onnx_transpose_operator():
             perm=permutation,
         )
 
-        nodes.append(transpose_node)
-        onnx_results.append(onnx_transpose(input_array, permutation))
+        onnx_result = onnx_transpose(input_array, permutation)
 
-    for node in nodes:
-        output_tensor = ggml_operators["Transpose"](node, tensors_dict, context, refs)
+        output_tensor = ggml_operators["Transpose"](
+            GgmlBackendRep(), transpose_node, tensors_dict, context, refs
+        )
         gf = ggml.ggml_build_forward(output_tensor)
         ggml.ggml_graph_compute_with_ctx(context, ctypes.pointer(gf), 1)
-        ggml_results.append(ggml.utils.to_numpy(output_tensor))
+        ggml_result = ggml.utils.to_numpy(output_tensor)
+        test_result = np.array_equal(ggml_result, onnx_result)
 
-    test_results = []
+        print("test_result:", test_result, "    Perm:", *permutation)
+        if not test_result:
+            print("ggml:\n", ggml_result)
+            print("onnx:\n", onnx_result)
+            print()
 
-    for i, result in enumerate(ggml_results):
-        test_results.append(np.allclose(result, onnx_results[i]))
-        # if not np.allclose(result, onnx_results[i]):
-        # print()
-        # print()
-        # print()
-        # print(permutations[i])
-        # print("ggml:")
-        # print(result)
-        # print("onnx:")
-        # print(onnx_results[i])
-        # break
-
-    print(test_results)
-
+    print()
+    print()
     ggml.ggml_free(context)
 
 
@@ -1385,7 +1396,9 @@ def test_ggml_onnx_range_operator():
         outputs=["range_output"],
     )
 
-    output_tensor = ggml_operators["Range"](range_node, tensors_dict, context, refs)
+    output_tensor = ggml_operators["Range"](
+        GgmlBackendRep(), range_node, tensors_dict, context, refs
+    )
     gf = ggml.ggml_build_forward(output_tensor)
     ggml.ggml_graph_compute_with_ctx(context, ctypes.pointer(gf), 1)
     result = ggml.utils.to_numpy(output_tensor)
@@ -1446,7 +1459,9 @@ def test_ggml_onnx_cast_operator():
         to=onnx.TensorProto.INT32,
     )
 
-    output_tensor = ggml_operators["Cast"](cast_node, tensors_dict, context, refs)
+    output_tensor = ggml_operators["Cast"](
+        GgmlBackendRep(), cast_node, tensors_dict, context, refs
+    )
     gf = ggml.ggml_build_forward(output_tensor)
     ggml.ggml_graph_compute_with_ctx(context, ctypes.pointer(gf), 1)
     result = ggml.utils.to_numpy(output_tensor)
@@ -1518,7 +1533,9 @@ def test_ggml_onnx_where_operator():
         outputs=["where_output"],
     )
 
-    output_tensor = ggml_operators["Where"](where_node, tensors_dict, context, refs)
+    output_tensor = ggml_operators["Where"](
+        GgmlBackendRep(), where_node, tensors_dict, context, refs
+    )
     gf = ggml.ggml_build_forward(output_tensor)
     ggml.ggml_graph_compute_with_ctx(context, ctypes.pointer(gf), 1)
     result = ggml.utils.to_numpy(output_tensor)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -52,3 +52,16 @@ def test_numpy_arrays_transposed():
         t = ggml.utils.from_numpy(x.T, ctx)
         x_t = ggml.utils.to_numpy(t)
         assert np.array_equal(x.T, x_t)
+
+
+def test_slice_tensor():
+    params = ggml.ggml_init_params(mem_size=16 * 1024 * 1024)
+    with ggml.utils.ggml_context_manager(params) as ctx:
+        x = np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int32)
+        t = ggml.utils.from_numpy(x, ctx)
+        t_slice = ggml.utils.slice_tensor(ctx, t, [
+            slice(0, 2),
+            slice(0, 1)
+        ])
+        x_slice = ggml.utils.to_numpy(t_slice)
+        assert np.array_equal(x_slice, x[:1, :2])


### PR DESCRIPTION
Adds a minimal onnx runtime for executing onnx graphs using ggml.

Currenty supports a subset of ggml operators required for running Instructor embedding models.

Future work includes:
- Full support for onnx operators
- On-the-fly weight quantization
- GPU / Metal Support