### PR TITLE
feat: Update minimal Python requires to 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = { text = "MIT" }
 authors = [
     { name = "Andrei Betlen", email = "abetlen@gmail.com" },
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
     "numpy>=1.20.0",
     "typing_extensions>=4.6.3",


### PR DESCRIPTION
Most functions use position-only parameters, which was introduced in Python 3.8. Therefore, ggml-python cannot be used with Python 3.7. We should bump the requires-python version to 3.8.