### PR TITLE
Update ggml library to v0.9.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,41 +1,121 @@
+# Copied from https://github.com/abetlen/llama-cpp-python/blob/main/CMakeLists.txt
+# Edits made to remove llama.cpp specific calls
 cmake_minimum_required(VERSION 3.21)
 
-project(
-    ${SKBUILD_PROJECT_NAME}
-    VERSION ${SKBUILD_PROJECT_VERSION}
-)
+project(ggml)
 
-message(SKBUILD_STATE="${SKBUILD_STATE}")
-
-if(SKBUILD_STATE STREQUAL "editable")
-    # Temporary fix for https://github.com/scikit-build/scikit-build-core/issues/374
-    set(GGML_PYTHON_INSTALL_DIR ${CMAKE_CURRENT_SOURCE_DIR}/ggml/lib)
-else()
-    set(GGML_PYTHON_INSTALL_DIR ${SKBUILD_PLATLIB_DIR}/ggml/lib)
-endif()
-
-set(BUILD_SHARED_LIBS "On")
-set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
-if (APPLE)
-    if (CMAKE_SYSTEM_PROCESSOR MATCHES "arm64")
-        set(GGML_AVX "Off" CACHE BOOL "ggml: enable AVX" FORCE)
-        set(GGML_AVX2 "Off" CACHE BOOL "ggml: enable AVX2" FORCE)
-        set(GGML_FMA "Off" CACHE BOOL "ggml: enable FMA" FORCE)
-        set(GGML_F16C "Off" CACHE BOOL "ggml: enable F16C" FORCE)
+function(ggml_python_install_target target)
+    if(NOT TARGET ${target})
+        return()
     endif()
 
-    set(GGML_METAL_EMBED_LIBRARY "On" CACHE BOOL "ggml: embed metal library" FORCE)
+    install(
+        TARGETS ${target}
+        LIBRARY DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/ggml/lib
+        RUNTIME DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/ggml/lib
+        ARCHIVE DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/ggml/lib
+        FRAMEWORK DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/ggml/lib
+        RESOURCE DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/ggml/lib
+    )
+    install(
+        TARGETS ${target}
+        LIBRARY DESTINATION ${SKBUILD_PLATLIB_DIR}/ggml/lib
+        RUNTIME DESTINATION ${SKBUILD_PLATLIB_DIR}/ggml/lib
+        ARCHIVE DESTINATION ${SKBUILD_PLATLIB_DIR}/ggml/lib
+        FRAMEWORK DESTINATION ${SKBUILD_PLATLIB_DIR}/ggml/lib
+        RESOURCE DESTINATION ${SKBUILD_PLATLIB_DIR}/ggml/lib
+    )
+    set_target_properties(${target} PROPERTIES
+        INSTALL_RPATH "$ORIGIN"
+        BUILD_WITH_INSTALL_RPATH TRUE
+    )
+    if(UNIX)
+        if(APPLE)
+            set_target_properties(${target} PROPERTIES
+                INSTALL_RPATH "@loader_path"
+                BUILD_WITH_INSTALL_RPATH TRUE
+            )
+        else()
+            set_target_properties(${target} PROPERTIES
+                INSTALL_RPATH "$ORIGIN"
+                BUILD_WITH_INSTALL_RPATH TRUE
+            )
+        endif()
+    endif()
+endfunction()
+
+set(BUILD_SHARED_LIBS "On")
+
+set(CMAKE_SKIP_BUILD_RPATH FALSE)
+
+# When building, don't use the install RPATH already
+# (but later on when installing)
+set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+
+# Add the automatically determined parts of the RPATH
+# which point to directories outside the build tree to the install RPATH
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+set(CMAKE_SKIP_RPATH FALSE)
+
+# Architecture detection and settings for Apple platforms
+if (APPLE)
+    # Get the target architecture
+    execute_process(
+        COMMAND uname -m
+        OUTPUT_VARIABLE HOST_ARCH
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+    # If CMAKE_OSX_ARCHITECTURES is not set, use the host architecture
+    if(NOT CMAKE_OSX_ARCHITECTURES)
+        set(CMAKE_OSX_ARCHITECTURES ${HOST_ARCH} CACHE STRING "Build architecture for macOS" FORCE)
+    endif()
+
+    message(STATUS "Host architecture: ${HOST_ARCH}")
+    message(STATUS "Target architecture: ${CMAKE_OSX_ARCHITECTURES}")
+
+    # Configure based on target architecture
+    if(CMAKE_OSX_ARCHITECTURES STREQUAL "x86_64")
+        # Intel Mac settings
+        set(GGML_AVX "OFF" CACHE BOOL "ggml: enable AVX" FORCE)
+        set(GGML_AVX2 "OFF" CACHE BOOL "ggml: enable AVX2" FORCE)
+        set(GGML_FMA "OFF" CACHE BOOL "ggml: enable FMA" FORCE)
+        set(GGML_F16C "OFF" CACHE BOOL "ggml: enable F16C" FORCE)
+    endif()
+
+    # Metal settings (enable for both architectures)
+    set(GGML_METAL "ON" CACHE BOOL "ggml: enable Metal" FORCE)
+    set(GGML_METAL_EMBED_LIBRARY "ON" CACHE BOOL "ggml: embed metal library" FORCE)
 endif()
+
+
 add_subdirectory(vendor/ggml)
-install(
-    TARGETS ggml 
-    ARCHIVE DESTINATION ${GGML_PYTHON_INSTALL_DIR}
-    LIBRARY DESTINATION ${GGML_PYTHON_INSTALL_DIR}
-    RUNTIME DESTINATION ${GGML_PYTHON_INSTALL_DIR}
-    FRAMEWORK DESTINATION ${GGML_PYTHON_INSTALL_DIR}
-    RESOURCE DESTINATION ${GGML_PYTHON_INSTALL_DIR}
-)
-install(
-    FILES $<TARGET_RUNTIME_DLLS:ggml>
-    DESTINATION ${GGML_PYTHON_INSTALL_DIR}
-)
+
+ggml_python_install_target(ggml)
+
+ggml_python_install_target(ggml-base)
+
+ggml_python_install_target(ggml-amx)
+ggml_python_install_target(ggml-blas)
+ggml_python_install_target(ggml-can)
+ggml_python_install_target(ggml-cpu)
+ggml_python_install_target(ggml-cuda)
+ggml_python_install_target(ggml-hip)
+ggml_python_install_target(ggml-kompute)
+ggml_python_install_target(ggml-metal)
+ggml_python_install_target(ggml-musa)
+ggml_python_install_target(ggml-rpc)
+ggml_python_install_target(ggml-sycl)
+ggml_python_install_target(ggml-vulkan)
+
+# Workaround for Windows + CUDA https://github.com/abetlen/llama-cpp-python/issues/563
+if (WIN32)
+    install(
+        FILES $<TARGET_RUNTIME_DLLS:ggml>
+        DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/ggml/lib
+    )
+    install(
+        FILES $<TARGET_RUNTIME_DLLS:ggml>
+        DESTINATION ${SKBUILD_PLATLIB_DIR}/ggml/lib
+    )
+endif()

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Andrei Betlen
+Copyright (c) 2023 Andrei Betlen [Original project author]
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![PyPI - License](https://img.shields.io/pypi/l/ggml-py)](https://pypi.org/project/ggml-py/)
 [![PyPI - Downloads](https://img.shields.io/pypi/dm/ggml-py)](https://pypi.org/project/ggml-py/)
 
-> ℹ️ Note this is a fork of the [original project](https://github.com/abetlen/ggml-python) which hasn't been updated July 2024. There have been a number of CVE security patches for `ggml / llama.cpp` since that date. This fork updates `ggml` to the latest. [See the llama.cpp security page for more on this](https://github.com/ggml-org/llama.cpp/security).
+> ℹ️ Note this is a fork of the [original project](https://github.com/abetlen/ggml-python) which hasn't been updated since July 2024. There have been a number of CVE security patches for `ggml / llama.cpp` since that date. This fork updates `ggml` to the latest. [See the llama.cpp security page for more on this](https://github.com/ggml-org/llama.cpp/security).
 
 Python bindings for the [`ggml`](https://github.com/ggerganov/ggml) tensor library for machine learning.
 

--- a/README.md
+++ b/README.md
@@ -1,42 +1,32 @@
 # Python bindings for [`ggml`](https://github.com/ggerganov/ggml)
 
-[![Documentation Status](https://readthedocs.org/projects/ggml-python/badge/?version=latest)](https://ggml-python.readthedocs.io/en/latest/?badge=latest)
-[![Tests](https://github.com/abetlen/ggml-python/actions/workflows/test.yaml/badge.svg)](https://github.com/abetlen/ggml-python/actions/workflows/test.yaml)
-[![PyPI](https://img.shields.io/pypi/v/ggml-python)](https://pypi.org/project/ggml-python/)
-[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/ggml-python)](https://pypi.org/project/ggml-python/)
-[![PyPI - License](https://img.shields.io/pypi/l/ggml-python)](https://pypi.org/project/ggml-python/)
-[![PyPI - Downloads](https://img.shields.io/pypi/dm/ggml-python)](https://pypi.org/project/ggml-python/)
+[![PyPI](https://img.shields.io/pypi/v/ggml-py)](https://pypi.org/project/ggml-py/)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/ggml-py)](https://pypi.org/project/ggml-py/)
+[![PyPI - License](https://img.shields.io/pypi/l/ggml-py)](https://pypi.org/project/ggml-py/)
+[![PyPI - Downloads](https://img.shields.io/pypi/dm/ggml-py)](https://pypi.org/project/ggml-py/)
 
+> ℹ️ Note this is a fork of the [original project](https://github.com/abetlen/ggml-python) which hasn't been updated July 2024. There have been a number of CVE security patches for `ggml / llama.cpp` since that date. This fork updates `ggml` to the latest. [See the llama.cpp security page for more on this](https://github.com/ggml-org/llama.cpp/security).
 
 Python bindings for the [`ggml`](https://github.com/ggerganov/ggml) tensor library for machine learning.
 
-> ⚠️ Neither this project nor `ggml` currently guarantee backwards-compatibility, if you are using this library in other applications I strongly recommend pinning to specific releases in your `requirements.txt` file.
-
-# Documentation
-
-- [Getting Started](https://ggml-python.readthedocs.io/en/latest/)
-- [API Reference](https://ggml-python.readthedocs.io/en/latest/api-reference/)
-- [Examples](https://github.com/abetlen/ggml-python/tree/main/examples)
-
 # Installation
 
-
 Requirements
-- Python 3.8+
+- Python 3.10+
 - C compiler (gcc, clang, msvc, etc)
 
-You can install `ggml-python` using `pip`:
+You can install `ggml-py` using `pip`:
 
 ```bash
-pip install ggml-python
+pip install ggml-py
 ```
 
 This will compile ggml using cmake which requires a c compiler installed on your system.
-To build ggml with specific features (ie. OpenBLAS, GPU Support, etc) you can pass specific cmake options through the `cmake.args` pip install configuration setting. For example to install ggml-python with cuBLAS support you can run:
+To build ggml with specific features (ie. OpenBLAS, GPU Support, etc) you can pass specific cmake options through the `cmake.args` pip install configuration setting. For example to install ggml-py with cuBLAS support you can run:
 
 ```bash
 pip install --upgrade pip
-pip install ggml-python --config-settings=cmake.args='-DGGML_CUDA=ON'
+pip install ggml-py --config-settings=cmake.args='-DGGML_CUDA=ON'
 ```
 
 ## Options
@@ -89,10 +79,10 @@ ggml.ggml_free(ctx)
 
 # Troubleshooting
 
-If you are having trouble installing `ggml-python` or activating specific features please try to install it with the `--verbose` and `--no-cache-dir` flags to get more information about any issues:
+If you are having trouble installing `ggml-py` or activating specific features please try to install it with the `--verbose` and `--no-cache-dir` flags to get more information about any issues:
 
 ```bash
-pip install ggml-python --verbose --no-cache-dir --force-reinstall --upgrade
+pip install ggml-py --verbose --no-cache-dir --force-reinstall --upgrade
 ```
 
 # License

--- a/ggml/__init__.py
+++ b/ggml/__init__.py
@@ -1,3 +1,3 @@
 from .ggml import *
 
-__version__ = "0.0.37"
+__version__ = "0.0.38"

--- a/ggml/__init__.py
+++ b/ggml/__init__.py
@@ -1,3 +1,3 @@
 from .ggml import *
 
-__version__ = "0.0.38"
+__version__ = "0.9.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "scikit_build_core.build"
 [project]
 name = "ggml_py"
 dynamic = ["version"]
-description = "Python bindings for ggml. Fork of original project updating ggml to latest."
+description = "Python bindings for ggml. Fork of the original project to use the latest version of ggml."
 readme = "README.md"
 license = { text = "MIT" }
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,24 +3,18 @@ requires = ["scikit-build-core[pyproject]>=0.5.1"]
 build-backend = "scikit_build_core.build"
 
 [project]
-name = "ggml_python"
+name = "ggml_py"
 dynamic = ["version"]
-description = "Python bindings for ggml"
+description = "Python bindings for ggml. Fork of original project updating ggml to latest."
 readme = "README.md"
 license = { text = "MIT" }
-authors = [
-    { name = "Andrei Betlen", email = "abetlen@gmail.com" },
-]
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 dependencies = [
     "numpy>=1.20.0",
     "typing_extensions>=4.6.3",
-    "importlib_resources>=6.4.0; python_version < '3.9'",
 ]
 classifiers = [
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -56,6 +50,5 @@ convert = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/abetlen/ggml-python"
-Documentation = "https://ggml-python.readthedocs.io/en/latest/"
-Issues = "https://github.com/abetlen/ggml-python/issues"
+Homepage = "https://github.com/neuml/ggml-python"
+Issues = "https://github.com/neuml/ggml-python/issues"


### PR DESCRIPTION
Hello.

As mentioned in #96, I'm looking to see if there is interest in updating this library to the latest release of [ggml](https://github.com/ggml-org/ggml/releases/tag/v0.9.4). 

I'd like to use this library but there are a number of serious security issues that have been [patched since the last release](https://github.com/ggml-org/llama.cpp/security).

<img width="1295" height="521" alt="image" src="https://github.com/user-attachments/assets/366ce542-b9cb-4938-9975-bfa32b8817e5" />

This PR updates this library to v0.9.4 of ggml. The following summarizes the changes.

- Update CMakeLists.txt to work with latest ggml library. Much of this is copied from the llama-cpp-python CMakeLists.txt file.
- Add `load_shared_library` from llama-cpp-python project
- Update quantization enum
- Remove functions no longer available in upstream project
- Add `ggml_backend_init_by_type` and `ggml_backend_init_best` methods
- Update vendor/ggml to v0.9.4

Please let me know if you have interest in this PR or if I should consider forking a project with these changes instead.
