### PR TITLE
ci: Update test workflow runners

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,11 +18,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: "true"
+          submodules: "recursive"
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: "pip"
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pip pytest cmake scikit-build setuptools
@@ -46,11 +47,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: "true"
+          submodules: "recursive"
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: "pip"
 
       - name: Install dependencies
         run: |
@@ -61,25 +63,61 @@ jobs:
           python -m pytest -s -vvvv
 
   build-macos:
-    runs-on: macos-13
+    runs-on: macos-15
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: "true"
+          submodules: "recursive"
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: "pip"
+      - name: System Info
+        run: |
+          uname -a
+          sysctl -n machdep.cpu.brand_string
+          python3 -c "import platform; print(platform.machine(), platform.architecture())"
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pip pytest cmake scikit-build setuptools
           python3 -m pip install \
             --verbose \
-            --config-settings cmake.args='-DCMAKE_BUILD_TYPE=Debug;-DCMAKE_CXX_FLAGS=-g3;-DCMAKE_C_FLAGS=-g3' \
+            --config-settings cmake.args='-DCMAKE_BUILD_TYPE=Debug;-DCMAKE_CXX_FLAGS=-g3;-DCMAKE_C_FLAGS=-g3;-DGGML_NATIVE=off' \
+            --config-settings cmake.verbose=true \
+            --config-settings logging.level=INFO \
+            --config-settings install.strip=false \
+            --editable .
+      - name: Test with pytest
+        run: |
+          python -m pytest -s -vvvv
+
+  build-macos-intel:
+    runs-on: macos-15-intel
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+          cache: "pip"
+      - name: System Info
+        run: |
+          uname -a
+          sysctl -n machdep.cpu.brand_string
+          python3 -c "import platform; print(platform.machine(), platform.architecture())"
+      - name: Install dependencies
+        run: |
+          python3 -m pip install --upgrade pip pytest cmake scikit-build setuptools
+          python3 -m pip install \
+            --verbose \
+            --config-settings cmake.args='-DCMAKE_BUILD_TYPE=Debug;-DCMAKE_CXX_FLAGS=-g3;-DCMAKE_C_FLAGS=-g3;-DGGML_NATIVE=off' \
             --config-settings cmake.verbose=true \
             --config-settings logging.level=INFO \
             --config-settings install.strip=false \
@@ -89,22 +127,28 @@ jobs:
           python -m pytest -s -vvvv
 
   build-macos-metal:
-    runs-on: macos-13
+    runs-on: macos-15
 
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: "true"
+          submodules: "recursive"
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: "3.9"
+          cache: "pip"
+      - name: System Info
+        run: |
+          uname -a
+          sysctl -n machdep.cpu.brand_string
+          python3 -c "import platform; print(platform.machine(), platform.architecture())"
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pip pytest cmake scikit-build setuptools
           python3 -m pip install \
             --verbose \
-            --config-settings cmake.args='-DCMAKE_BUILD_TYPE=Debug;-DCMAKE_CXX_FLAGS=-g3;-DCMAKE_C_FLAGS=-g3;-DGGML_METAL=On' \
+            --config-settings cmake.args='-DCMAKE_BUILD_TYPE=Debug;-DCMAKE_CXX_FLAGS=-g3;-DCMAKE_C_FLAGS=-g3;-DGGML_NATIVE=off;-DGGML_METAL=On' \
             --config-settings cmake.verbose=true \
             --config-settings logging.level=INFO \
             --config-settings install.strip=false \

--- a/ggml/ggml.py
+++ b/ggml/ggml.py
@@ -11645,22 +11645,6 @@ GGML_METAL_MAX_BUFFERS = 64
 # //
 
 
-# GGML_API void ggml_backend_metal_log_set_callback(ggml_log_callback log_callback, void * user_data);
-@ggml_function(
-    "ggml_backend_metal_log_set_callback",
-    [
-        ggml_log_callback,
-        ctypes.c_void_p,
-    ],
-    None,
-    enabled=GGML_USE_METAL,
-)
-def ggml_backend_metal_log_set_callback(
-    log_callback, user_data: Union[ctypes.c_void_p, int, None], /  # type: ignore
-):
-    ...
-
-
 # GGML_API ggml_backend_t ggml_backend_metal_init(void);
 @ggml_function(
     "ggml_backend_metal_init", [], ggml_backend_t_ctypes, enabled=GGML_USE_METAL
@@ -11682,46 +11666,23 @@ def ggml_backend_is_metal(
     ...
 
 
-# GML_API GGML_CALL ggml_backend_buffer_t ggml_backend_metal_buffer_from_ptr(void * data, size_t size, size_t max_size);
+# GGML_API void ggml_backend_metal_set_abort_callback(ggml_backend_t backend, ggml_abort_callback abort_callback, void * user_data);
 @ggml_function(
-    "ggml_backend_metal_buffer_from_ptr",
+    "ggml_backend_metal_set_abort_callback",
     [
+        ggml_backend_t_ctypes,
+        ggml_abort_callback,
         ctypes.c_void_p,
-        ctypes.c_size_t,
-        ctypes.c_size_t,
     ],
-    ggml_backend_buffer_t_ctypes,
-    enabled=GGML_USE_METAL,
-)
-def ggml_backend_metal_buffer_from_ptr(
-    data: Union[ctypes.c_void_p, int, None],
-    size: Union[ctypes.c_size_t, int],
-    max_size: Union[ctypes.c_size_t, int],
-) -> Optional[ggml_backend_buffer_t]:
-    ...
-
-
-# GGML_API void ggml_backend_metal_set_n_cb(ggml_backend_t backend, int n_cb);
-@ggml_function(
-    "ggml_backend_metal_set_n_cb",
-    [ggml_backend_t_ctypes, ctypes.c_int],
     None,
     enabled=GGML_USE_METAL,
 )
-def ggml_backend_metal_set_n_cb(
-    backend: Union[ggml_backend_t, int], n_cb: Union[ctypes.c_int, int], /
+def ggml_backend_metal_set_abort_callback(
+    backend: Union[ggml_backend_t, int],
+    abort_callback,  # type: ignore
+    user_data: Union[ctypes.c_void_p, int, None],
+    /,
 ):
-    ...
-
-
-# GGML_API GGML_CALL ggml_backend_buffer_type_t ggml_backend_metal_buffer_type(void);
-@ggml_function(
-    "ggml_backend_metal_buffer_type",
-    [],
-    ggml_backend_buffer_type_t_ctypes,
-    enabled=GGML_USE_METAL,
-)
-def ggml_backend_metal_buffer_type() -> Optional[ggml_backend_buffer_type_t]:
     ...
 
 
@@ -11754,6 +11715,17 @@ def ggml_backend_metal_supports_family(
     enabled=GGML_USE_METAL,
 )
 def ggml_backend_metal_capture_next_compute(backend: Union[ggml_backend_t, int], /):
+    ...
+
+
+# GGML_API ggml_backend_reg_t ggml_backend_metal_reg(void);
+@ggml_function(
+    "ggml_backend_metal_reg",
+    [],
+    ggml_backend_reg_t_ctypes,
+    enabled=GGML_USE_METAL,
+)
+def ggml_backend_metal_reg() -> Optional[ggml_backend_reg_t]:
     ...
 
 


### PR DESCRIPTION
- Update the test workflow's macOS checks to use the newer `macos-15` runner and add a focused `macos-15-intel` check.
- Match the llama-cpp-python test workflow pattern by logging macOS system info and using `GGML_NATIVE=off` on macOS test builds.
- Switch test workflow checkouts to recursive submodules and enable pip caching for setup-python.
- Fix the Metal backend import failure exposed by the new macOS runners by removing stale Metal bindings that are not present in ggml 0.13.1 and adding current `ggml-metal.h` bindings for `ggml_backend_metal_set_abort_callback` and `ggml_backend_metal_reg`.