### PR TITLE
ci: update pre-built wheels to py3-none and add CUDA 11.8-13.2 support

### DIFF
--- a/.github/workflows/wheels-cuda.yaml
+++ b/.github/workflows/wheels-cuda.yaml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   define_matrix:
     name: Define Build Matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     defaults:
@@ -20,10 +20,17 @@ jobs:
         id: set-matrix
         run: |
           $matrix = @{
-              'os' = @('ubuntu-20.04', 'windows-latest')
-              'pyver' = @("3.10", "3.11", "3.12")
-              'cuda' = @("12.1.1", "12.2.2", "12.3.2", "12.4.1")
+              'os' = @('ubuntu-22.04', 'windows-2022')
+              # wheel.py-api = "py3" makes the CUDA wheel interpreter-agnostic,
+              # so one builder per toolkit version is sufficient.
+              'pyver' = @("3.9")
+              'cuda' = @("11.8.0", "12.1.1", "12.2.2", "12.3.2", "12.4.1", "12.5.1", "13.0.2", "13.2.1")
               'releasetag' = @("basic")
+              'exclude' = @(
+                @{ 'os' = 'windows-2022'; 'cuda' = '12.1.1' },
+                @{ 'os' = 'windows-2022'; 'cuda' = '12.2.2' },
+                @{ 'os' = 'windows-2022'; 'cuda' = '12.3.2' }
+              )
           }
 
           $matrixOut = ConvertTo-Json $matrix -Compress
@@ -43,6 +50,19 @@ jobs:
       AVXVER: ${{ matrix.releasetag }}
 
     steps:
+      - name: Set up MSVC for CUDA 11.8
+        if: runner.os == 'Windows' && matrix.cuda == '11.8.0'
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+          toolset: 14.29
+
+      - name: Set up MSVC
+        if: runner.os == 'Windows' && matrix.cuda != '11.8.0'
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+
       - uses: actions/checkout@v4
         with:
           submodules: "recursive"
@@ -50,43 +70,16 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.pyver }}
+          cache: "pip"
 
       - name: Setup Mamba
-        uses: conda-incubator/setup-miniconda@v3.0.4
+        uses: conda-incubator/setup-miniconda@v3.1.0
         with:
-          activate-environment: "build"
+          activate-environment: "ggml"
           python-version: ${{ matrix.pyver }}
-          miniforge-variant: Mambaforge
           miniforge-version: latest
-          use-mamba: true
           add-pip-as-python-dependency: true
           auto-activate-base: false
-
-      - name: VS Integration Cache
-        id: vs-integration-cache
-        if: runner.os == 'Windows'
-        uses: actions/cache@v4.0.2
-        with:
-          path: ./MSBuildExtensions
-          key: cuda-${{ matrix.cuda }}-vs-integration
-
-      - name: Get Visual Studio Integration
-        if: runner.os == 'Windows' && steps.vs-integration-cache.outputs.cache-hit != 'true'
-        run: |
-          if ($env:CUDAVER -eq '12.1.1') {$x = '12.1.0'} else {$x = $env:CUDAVER}
-          $links = (Invoke-RestMethod 'https://raw.githubusercontent.com/Jimver/cuda-toolkit/master/src/links/windows-links.ts').Trim().split().where({$_ -ne ''})
-          for ($i=$q=0;$i -lt $links.count -and $q -lt 2;$i++) {if ($links[$i] -eq "'$x',") {$q++}}
-          Invoke-RestMethod $links[$i].Trim("'") -OutFile 'cudainstaller.zip'
-          & 'C:\Program Files\7-Zip\7z.exe' e cudainstaller.zip -oMSBuildExtensions -r *\MSBuildExtensions\* > $null
-          Remove-Item 'cudainstaller.zip'
-
-      - name: Install Visual Studio Integration
-        if: runner.os == 'Windows'
-        run: |
-          $y = (gi '.\MSBuildExtensions').fullname + '\*'
-          (gi 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Microsoft\VC\*\BuildCustomizations').fullname.foreach({cp $y $_})
-          $cupath = 'CUDA_PATH_V' + $env:CUDAVER.Remove($env:CUDAVER.LastIndexOf('.')).Replace('.','_')
-          echo "$cupath=$env:CONDA_PREFIX" >> $env:GITHUB_ENV
 
       - name: Install Dependencies
         env:
@@ -94,37 +87,148 @@ jobs:
           MAMBA_NO_LOW_SPEED_LIMIT: "1"
         run: |
           $cudaVersion = $env:CUDAVER
-          mamba install -y 'cuda' -c nvidia/label/cuda-$cudaVersion
-          python -m pip install build wheel
+          $cudaChannel = "nvidia/label/cuda-$cudaVersion"
+          if ($cudaVersion -eq '11.8.0') {
+            if ($IsLinux) {
+              $cudaPackages = @(
+                "${cudaChannel}::cuda-nvcc_linux-64=11.8.0",
+                "${cudaChannel}::cuda-cccl=11.8.89",
+                "${cudaChannel}::cuda-cudart=11.8.89",
+                "${cudaChannel}::cuda-cudart-dev=11.8.89",
+                "${cudaChannel}::cuda-driver-dev=11.8.89",
+                "${cudaChannel}::libcublas=11.11.3.6",
+                "${cudaChannel}::libcublas-dev=11.11.3.6"
+              )
+            } elseif ($IsWindows) {
+              $cudaPackages = @(
+                "${cudaChannel}::cuda-nvcc_win-64=11.8.0",
+                "${cudaChannel}::cuda-cccl=11.8.89",
+                "${cudaChannel}::cuda-cudart=11.8.89",
+                "${cudaChannel}::cuda-cudart-dev=11.8.89",
+                "${cudaChannel}::libcublas=11.11.3.6",
+                "${cudaChannel}::libcublas-dev=11.11.3.6"
+              )
+            } else {
+              throw 'Unsupported CUDA wheel build platform'
+            }
+            mamba install -y --channel-priority flexible --override-channels -c $cudaChannel $cudaPackages
+          } elseif ($IsLinux) {
+            mamba install -y --channel-priority flexible --override-channels -c $cudaChannel "${cudaChannel}::cuda-toolkit=$cudaVersion" "${cudaChannel}::cuda-nvcc_linux-64" "${cudaChannel}::cuda-cccl" "${cudaChannel}::cuda-cudart" "${cudaChannel}::cuda-cudart-dev"
+          } elseif ($IsWindows) {
+            if ($cudaVersion -like '12.5.*' -or [version]$cudaVersion -ge [version]"13.0") {
+              # The Windows 12.5+ toolkit meta-package pulls compiler activation
+              # scripts that overflow cmd.exe after MSVC is already initialized.
+              mamba install -y --channel-priority flexible --override-channels -c $cudaChannel "${cudaChannel}::cuda-nvcc_win-64" "${cudaChannel}::cuda-cccl" "${cudaChannel}::cuda-libraries-dev=$cudaVersion" "${cudaChannel}::cuda-cudart" "${cudaChannel}::cuda-cudart-dev"
+            } else {
+              mamba install -y --channel-priority flexible --override-channels -c $cudaChannel "${cudaChannel}::cuda-toolkit=$cudaVersion" "${cudaChannel}::cuda-nvcc_win-64" "${cudaChannel}::cuda-cccl" "${cudaChannel}::cuda-cudart" "${cudaChannel}::cuda-cudart-dev"
+            }
+          } else {
+            throw 'Unsupported CUDA wheel build platform'
+          }
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
+          if ($IsWindows) {
+            python -m pip install build wheel ninja
+          } else {
+            python -m pip install build wheel
+          }
 
       - name: Build Wheel
         run: |
-          $cudaVersion = $env:CUDAVER.Remove($env:CUDAVER.LastIndexOf('.')).Replace('.','')
-          $env:CUDA_PATH = $env:CONDA_PREFIX
-          $env:CUDA_HOME = $env:CONDA_PREFIX
-          $env:CUDA_TOOLKIT_ROOT_DIR = $env:CONDA_PREFIX
+          $pathSeparator = if ($IsWindows) { ';' } else { ':' }
+          if ($IsWindows) {
+            $cudaRoot = Join-Path $env:CONDA_PREFIX 'Library'
+          } elseif (Test-Path (Join-Path $env:CONDA_PREFIX 'targets/x86_64-linux/include/cuda_runtime.h')) {
+            $cudaRoot = Join-Path $env:CONDA_PREFIX 'targets/x86_64-linux'
+          } else {
+            $cudaRoot = $env:CONDA_PREFIX
+          }
+
+          $env:CUDA_PATH = $cudaRoot
+          $env:CUDA_HOME = $cudaRoot
+          $env:CUDAToolkit_ROOT = $cudaRoot
+          $env:CUDA_TOOLKIT_ROOT_DIR = $cudaRoot
+          $cudaHostCompilerArg = ''
+          $cudaRootCmake = $cudaRoot.Replace('\', '/')
+          $env:CMAKE_ARGS = "-DCUDAToolkit_ROOT=$cudaRootCmake -DCUDA_TOOLKIT_ROOT_DIR=$cudaRootCmake"
           if ($IsLinux) {
-            $env:LD_LIBRARY_PATH = $env:CONDA_PREFIX + '/lib:' + $env:LD_LIBRARY_PATH
+            if ([version]$env:CUDAVER -lt [version]"12.0" -and (Test-Path '/usr/bin/g++-11')) {
+              $env:CC = '/usr/bin/gcc-11'
+              $env:CXX = '/usr/bin/g++-11'
+              $env:CUDAHOSTCXX = '/usr/bin/g++-11'
+              $cudaHostCompilerArg = " -DCMAKE_CUDA_HOST_COMPILER=$env:CUDAHOSTCXX"
+            } elseif (Test-Path '/usr/bin/g++-12') {
+              $env:CC = '/usr/bin/gcc-12'
+              $env:CXX = '/usr/bin/g++-12'
+              $env:CUDAHOSTCXX = '/usr/bin/g++-12'
+              $cudaHostCompilerArg = " -DCMAKE_CUDA_HOST_COMPILER=$env:CUDAHOSTCXX"
+            }
+            $env:CMAKE_ARGS = "-DCUDAToolkit_ROOT=$cudaRoot -DCUDA_TOOLKIT_ROOT_DIR=$cudaRoot$cudaHostCompilerArg"
+            $env:CPATH = "$cudaRoot/include$pathSeparator$env:CPATH"
+            $env:CPLUS_INCLUDE_PATH = "$cudaRoot/include$pathSeparator$env:CPLUS_INCLUDE_PATH"
+            $env:LIBRARY_PATH = "$cudaRoot/lib$pathSeparator$env:CONDA_PREFIX/lib$pathSeparator$env:LIBRARY_PATH"
+            $env:LD_LIBRARY_PATH = "$cudaRoot/lib$pathSeparator$env:CONDA_PREFIX/lib$pathSeparator$env:LD_LIBRARY_PATH"
+          } elseif ($IsWindows) {
+            $ninjaPath = ((Get-Command ninja -ErrorAction Stop).Source).Replace('\', '/')
+            $env:CMAKE_GENERATOR = 'Ninja'
+            $env:CMAKE_MAKE_PROGRAM = $ninjaPath
+            $env:PATH = "$(Join-Path $cudaRoot 'bin')$pathSeparator$env:PATH"
           }
+
+          if ($IsWindows) {
+            $nvccCandidates = @(
+              (Join-Path $cudaRoot 'bin\nvcc.exe'),
+              (Join-Path $env:CONDA_PREFIX 'Library\bin\nvcc.exe'),
+              (Join-Path $env:CONDA_PREFIX 'bin\nvcc.exe')
+            )
+          } else {
+            $nvccCandidates = @(
+              (Join-Path $env:CONDA_PREFIX 'bin/nvcc'),
+              (Join-Path $env:CONDA_PREFIX 'targets/x86_64-linux/bin/nvcc')
+            )
+          }
+          $nvccPath = $nvccCandidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+          if (-not $nvccPath) {
+            throw 'Failed to find nvcc in the conda environment'
+          }
+          $env:CUDACXX = $nvccPath
+          $env:PATH = "$(Split-Path $nvccPath)$pathSeparator$env:PATH"
+          if ($IsWindows) {
+            $nvccPathCmake = $nvccPath.Replace('\', '/')
+            $env:CUDACXX = $nvccPathCmake
+            $env:CMAKE_ARGS = "-DCMAKE_CUDA_COMPILER=$nvccPathCmake -DCMAKE_CUDA_COMPILER_ARG1=-allow-unsupported-compiler -DCMAKE_MAKE_PROGRAM=$env:CMAKE_MAKE_PROGRAM $env:CMAKE_ARGS"
+          }
+          $nvccVersion = ((& $nvccPath --version) | Select-String 'release ([0-9]+\.[0-9]+)').Matches[0].Groups[1].Value
+          if (-not $nvccVersion) {
+            throw 'Failed to detect the installed CUDA toolkit version'
+          }
+          $cudaTagVersion = $nvccVersion.Replace('.','')
           $env:VERBOSE = '1'
-          $env:CMAKE_ARGS = '-DGGML_CUDA=on -DCMAKE_CUDA_ARCHITECTURES=all'
-          $env:CMAKE_ARGS = "-DGGML_CUDA_FORCE_MMQ=ON $env:CMAKE_ARGS"
-          if ($env:AVXVER -eq 'AVX') {
-            $env:CMAKE_ARGS = $env:CMAKE_ARGS + ' -DGGML_AVX2=off -DGGML_FMA=off -DGGML_F16C=off'
+          $cudaArchs = "60-real;61-real;70-real;75-real;80-real;86-real;89-real;90-real;90-virtual"
+          if ([version]$nvccVersion -lt [version]"12.0") {
+            # CUDA 11.8 cannot compile ggml's Hopper PDL device calls.
+            $cudaArchs = "60-real;61-real;70-real;75-real;80-real;86-real;89-real"
+          } elseif ([version]$nvccVersion -ge [version]"13.0") {
+            # CUDA 13 dropped offline compilation support for pre-Turing targets.
+            $cudaArchs = "75-real;80-real;86-real;89-real;90-real;90-virtual"
           }
-          if ($env:AVXVER -eq 'AVX512') {
-            $env:CMAKE_ARGS = $env:CMAKE_ARGS + ' -DGGML_AVX512=on'
-          }
+          # Build real cubins for the supported GPUs and keep one
+          # forward-compatible PTX target instead of embedding PTX for every SM.
+          $env:CMAKE_ARGS = "-DGGML_CUDA_FORCE_MMQ=ON -DGGML_CUDA=on -DCMAKE_CUDA_ARCHITECTURES=$cudaArchs -DCMAKE_CUDA_FLAGS=-allow-unsupported-compiler -DCMAKE_CUDA_FLAGS_INIT=-allow-unsupported-compiler $env:CMAKE_ARGS"
+          $env:CMAKE_ARGS = $env:CMAKE_ARGS + ' -DGGML_AVX2=off -DGGML_FMA=off -DGGML_F16C=off'
           if ($env:AVXVER -eq 'basic') {
-            $env:CMAKE_ARGS = $env:CMAKE_ARGS + ' -DGGML_AVX=off -DGGML_AVX2=off -DGGML_FMA=off -DGGML_F16C=off'
+            $env:CMAKE_ARGS = $env:CMAKE_ARGS + ' -DGGML_AVX=off'
           }
-          $buildtag = "-cu$cudaVersion"
           python -m build --wheel
-          Write-Output "CUDA_VERSION=$cudaVersion" >> $env:GITHUB_ENV
+          # Publish tags that reflect the actual installed toolkit version.
+          Write-Output "CUDA_VERSION=$cudaTagVersion" >> $env:GITHUB_ENV
 
       - uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
         with:
           files: dist/*
+          # Set tag_name to <tag>-cu<cuda_version>.
           tag_name: ${{ github.ref_name }}-cu${{ env.CUDA_VERSION }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/wheels-index.yaml
+++ b/.github/workflows/wheels-index.yaml
@@ -35,10 +35,14 @@ jobs:
       - name: Build
         run: |
           ./scripts/releases-to-pep-503.sh index/whl/cpu '^[v]?[0-9]+\.[0-9]+\.[0-9]+$'
+          ./scripts/releases-to-pep-503.sh index/whl/cu118 '^[v]?[0-9]+\.[0-9]+\.[0-9]+-cu118$'
           ./scripts/releases-to-pep-503.sh index/whl/cu121 '^[v]?[0-9]+\.[0-9]+\.[0-9]+-cu121$'
           ./scripts/releases-to-pep-503.sh index/whl/cu122 '^[v]?[0-9]+\.[0-9]+\.[0-9]+-cu122$'
           ./scripts/releases-to-pep-503.sh index/whl/cu123 '^[v]?[0-9]+\.[0-9]+\.[0-9]+-cu123$'
           ./scripts/releases-to-pep-503.sh index/whl/cu124 '^[v]?[0-9]+\.[0-9]+\.[0-9]+-cu124$'
+          ./scripts/releases-to-pep-503.sh index/whl/cu125 '^[v]?[0-9]+\.[0-9]+\.[0-9]+-cu125$'
+          ./scripts/releases-to-pep-503.sh index/whl/cu130 '^[v]?[0-9]+\.[0-9]+\.[0-9]+-cu130$'
+          ./scripts/releases-to-pep-503.sh index/whl/cu132 '^[v]?[0-9]+\.[0-9]+\.[0-9]+-cu132$'
           ./scripts/releases-to-pep-503.sh index/whl/metal '^[v]?[0-9]+\.[0-9]+\.[0-9]+-metal$'
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/wheels-metal.yaml
+++ b/.github/workflows/wheels-metal.yaml
@@ -6,82 +6,58 @@ permissions:
   contents: write
 
 jobs:
-  define_matrix:
-    name: Define Build Matrix
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-    defaults:
-      run:
-        shell: pwsh
-
-    steps:
-      - name: Define Job Output
-        id: set-matrix
-        run: |
-          $matrix = @{
-              'os' = @('macos-11', 'macos-12', 'macos-13')
-              'pyver' = @('3.10', '3.11', '3.12')
-          }
-
-          $matrixOut = ConvertTo-Json $matrix -Compress
-          Write-Output ('matrix=' + $matrixOut) >> $env:GITHUB_OUTPUT
-
   build_wheels:
-    name: ${{ matrix.os }} Python ${{ matrix.pyver }}
-    needs: define_matrix
+    name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
-      matrix: ${{ fromJSON(needs.define_matrix.outputs.matrix) }}
-    env:
-      OSVER: ${{ matrix.os }}
+      matrix:
+        os: [macos-14, macos-15]
 
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: "recursive"
 
+      # Used to host cibuildwheel.
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.pyver }}
+          python-version: "3.12"
+          cache: "pip"
 
-      - name: Install Dependencies
-        run: |
-          python -m pip install build wheel cmake
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.22.0
+        env:
+          CIBW_REPAIR_WHEEL_COMMAND: ""
+          CIBW_ARCHS: "arm64"
+          CIBW_ENVIRONMENT: CMAKE_ARGS="-DCMAKE_OSX_ARCHITECTURES=arm64 -DCMAKE_APPLE_SILICON_PROCESSOR=arm64 -DGGML_NATIVE=off -DGGML_METAL=on -DCMAKE_CROSSCOMPILING=ON"
+          # The release wheel is tagged py3-none, so one build covers all
+          # supported Python versions and avoids duplicate wheel names.
+          CIBW_BUILD: "cp39-*"
+        with:
+          package-dir: .
+          output-dir: wheelhouse
 
-      - name: Build Wheel
-        run: |
-          XCODE15PATH="/Applications/Xcode_15.0.app/Contents/Developer"
-          XCODE15BINPATH="${XCODE15PATH}/Toolchains/XcodeDefault.xctoolchain/usr/bin"
-          export CMAKE_ARGS="-DGGML_NATIVE=off -DGGML_METAL=on"
-          [[ "$OSVER" == "macos-13" ]] && export CC="${XCODE15BINPATH}/cc" && export CXX="${XCODE15BINPATH}/c++" && export MACOSX_DEPLOYMENT_TARGET="13.0"
-          [[ "$OSVER" == "macos-12" ]] && export MACOSX_DEPLOYMENT_TARGET="12.0"
-          [[ "$OSVER" == "macos-11" ]] && export MACOSX_DEPLOYMENT_TARGET="11.0"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-mac_${{ matrix.os }}
+          path: ./wheelhouse/*.whl
 
-          export CMAKE_OSX_ARCHITECTURES="arm64" && export ARCHFLAGS="-arch arm64"
-          VERBOSE=1 python -m build --wheel
+  release:
+    name: Release
+    needs: [build_wheels]
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
 
-          if [[ "$OSVER" == "macos-13" ]]; then
-            export SDKROOT="${XCODE15PATH}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.0.sdk"
-            export MACOSX_DEPLOYMENT_TARGET="14.0"
-            VERBOSE=1 python -m build --wheel
-          fi
-
-          for file in ./dist/*.whl; do cp "$file" "${file/arm64.whl/aarch64.whl}"; done
-
-          export CMAKE_OSX_ARCHITECTURES="x86_64" && export CMAKE_ARGS="-DGGML_NATIVE=off -DGGML_AVX=off -DGGML_AVX2=off -DGGML_FMA=off -DGGML_F16C=off -DGGML_METAL=on" && export ARCHFLAGS="-arch x86_64"
-          VERBOSE=1 python -m build --wheel
-
-          if [[ "$OSVER" == "macos-13" ]]; then
-            export SDKROOT="${XCODE15PATH}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.0.sdk"
-            export MACOSX_DEPLOYMENT_TARGET="14.0"
-            VERBOSE=1 python -m build --wheel
-          fi
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+          path: dist
 
       - uses: softprops/action-gh-release@v2
         with:
           files: dist/*
-          # set release name to <tag>-metal
+          # Set release name to <tag>-metal.
           tag_name: ${{ github.ref_name }}-metal
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -11,21 +11,38 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-11, windows-2022]
+        os: [ubuntu-22.04, windows-2022, macos-14, macos-15]
 
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: "recursive"
 
+      # Used to host cibuildwheel.
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.18.1
+        uses: pypa/cibuildwheel@v2.22.0
         env:
-          # disable repair
+          # Keep repair disabled by default for non-Linux platforms in this job.
           CIBW_REPAIR_WHEEL_COMMAND: ""
-          # skip building wheels for these platforms
-          CIBW_SKIP: pp* cp36-* cp37-* *-musllinux*
-          CMAKE_ARGS: -DGGML_METAL=OFF
+          # Linux needs auditwheel repair so manylinux and musllinux wheels are
+          # published with distinct platform tags instead of generic linux tags.
+          CIBW_REPAIR_WHEEL_COMMAND_LINUX: "LD_LIBRARY_PATH=/project/ggml/lib auditwheel repair -w {dest_dir} {wheel}"
+          # The release wheel is tagged py3-none, so one build per platform
+          # covers all supported Python versions and avoids duplicate names.
+          CIBW_BUILD_LINUX: "cp38-*"
+          CIBW_BUILD_MACOS: "cp39-*"
+          CIBW_BUILD_WINDOWS: "cp39-*"
+          # Skip cibuildwheel's default i686 sidecar and keep release wheels on
+          # a portable CPU baseline instead of the hosted runner's native flags.
+          CIBW_ARCHS_LINUX: "auto64"
+          CIBW_ARCHS_WINDOWS: "AMD64"
+          CIBW_ENVIRONMENT_LINUX: CMAKE_ARGS="-DGGML_NATIVE=off -DGGML_METAL=OFF"
+          CIBW_ENVIRONMENT_MACOS: CMAKE_ARGS="-DGGML_NATIVE=off -DGGML_METAL=OFF"
+          CIBW_ENVIRONMENT_WINDOWS: CMAKE_ARGS="-DGGML_NATIVE=off"
         with:
           package-dir: .
           output-dir: wheelhouse
@@ -37,24 +54,24 @@ jobs:
 
   build_wheels_arm64:
     name: Build arm64 wheels
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: "recursive"
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: linux/arm64
-
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.18.1
+        uses: pypa/cibuildwheel@v2.22.0
         env:
-          CIBW_SKIP: "*musllinux* pp*"
-          CIBW_REPAIR_WHEEL_COMMAND: ""
+          CIBW_SKIP: "pp*"
+          CIBW_REPAIR_WHEEL_COMMAND: "LD_LIBRARY_PATH=$PWD/ggml/lib auditwheel repair -w {dest_dir} {wheel}"
           CIBW_ARCHS: "aarch64"
-          CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-* cp312-*"
+          # Keep native arm64 builds on a portable CPU baseline instead of
+          # tuning wheels to the hosted runner.
+          CIBW_ENVIRONMENT: CMAKE_ARGS="-DGGML_NATIVE=off -DGGML_METAL=OFF"
+          # The release wheel is tagged py3-none, so one build covers all
+          # supported Python versions and avoids duplicate wheel names.
+          CIBW_BUILD: "cp38-*"
         with:
           output-dir: wheelhouse
 
@@ -66,7 +83,8 @@ jobs:
 
   release:
     name: Release
-    needs: [build_wheels]
+    needs: [build_wheels, build_wheels_arm64]
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,5 +7,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- chore: Add Python 3.13 and 3.14 support metadata and update wheel workflows for `py3-none` builds
+- ci: Add Python 3.13 and 3.14 support metadata and update wheel workflows for `py3-none` builds
 - feat: Update ggml to ggml-org/ggml@1e33fed3 and sync Python bindings by @abetlen in #100

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,5 +7,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- ci: Add Python 3.13 and 3.14 support metadata and update wheel workflows for `py3-none` builds
+- ci: update pre-built wheels to py3-none and add CUDA 11.8-13.2 support
 - feat: Update ggml to ggml-org/ggml@1e33fed3 and sync Python bindings by @abetlen in #100

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- chore: Add Python 3.13 and 3.14 support metadata and update wheel workflows for `py3-none` builds
 - feat: Update ggml to ggml-org/ggml@1e33fed3 and sync Python bindings by @abetlen in #100

--- a/README.md
+++ b/README.md
@@ -31,7 +31,10 @@ You can install `ggml-python` using `pip`:
 pip install ggml-python
 ```
 
-This will compile ggml using cmake which requires a c compiler installed on your system.
+Release wheels are tagged `py3-none` and support Python 3.8 through 3.14 when a matching platform wheel is available.
+CUDA release wheel builds track CUDA 11.8, 12.1, 12.2, 12.3, 12.4, 12.5, 13.0, and 13.2.
+
+When installing from source, this will compile ggml using cmake which requires a c compiler installed on your system.
 To build ggml with specific features (ie. OpenBLAS, GPU Support, etc) you can pass specific cmake options through the `cmake.args` pip install configuration setting. For example to install ggml-python with cuBLAS support you can run:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -31,10 +31,48 @@ You can install `ggml-python` using `pip`:
 pip install ggml-python
 ```
 
-Release wheels are tagged `py3-none` and support Python 3.8 through 3.14 when a matching platform wheel is available.
-CUDA release wheel builds track CUDA 11.8, 12.1, 12.2, 12.3, 12.4, 12.5, 13.0, and 13.2.
+## Pre-built Wheels
 
-When installing from source, this will compile ggml using cmake which requires a c compiler installed on your system.
+It is also possible to install a pre-built wheel with basic CPU support:
+
+```bash
+pip install ggml-python \
+  --extra-index-url https://abetlen.github.io/ggml-python/whl/cpu
+```
+
+Pre-built CUDA wheels are available for CUDA 11.8, 12.1, 12.2, 12.3, 12.4, 12.5, 13.0, and 13.2:
+
+```bash
+pip install ggml-python \
+  --extra-index-url https://abetlen.github.io/ggml-python/whl/<cuda-version>
+```
+
+Where `<cuda-version>` is one of the following:
+
+- `cu118`: CUDA 11.8
+- `cu121`: CUDA 12.1
+- `cu122`: CUDA 12.2
+- `cu123`: CUDA 12.3
+- `cu124`: CUDA 12.4
+- `cu125`: CUDA 12.5
+- `cu130`: CUDA 13.0
+- `cu132`: CUDA 13.2
+
+For example, to install the CUDA 12.1 wheel:
+
+```bash
+pip install ggml-python \
+  --extra-index-url https://abetlen.github.io/ggml-python/whl/cu121
+```
+
+Pre-built Metal wheels are available for Apple Silicon macOS:
+
+```bash
+pip install ggml-python \
+  --extra-index-url https://abetlen.github.io/ggml-python/whl/metal
+```
+
+When installing from source, pip compiles ggml with CMake and requires a C compiler installed on your system.
 To build ggml with specific features (ie. OpenBLAS, GPU Support, etc) you can pass specific cmake options through the `cmake.args` pip install configuration setting. For example to install ggml-python with cuBLAS support you can run:
 
 ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,10 +28,48 @@ You can install `ggml-python` using `pip`:
 pip install ggml-python
 ```
 
-Release wheels are tagged `py3-none` and support Python 3.8 through 3.14 when a matching platform wheel is available.
-CUDA release wheel builds track CUDA 11.8, 12.1, 12.2, 12.3, 12.4, 12.5, 13.0, and 13.2.
+## Pre-built Wheels
 
-When installing from source, this will compile ggml using cmake which requires a c compiler installed on your system.
+It is also possible to install a pre-built wheel with basic CPU support:
+
+```bash
+pip install ggml-python \
+  --extra-index-url https://abetlen.github.io/ggml-python/whl/cpu
+```
+
+Pre-built CUDA wheels are available for CUDA 11.8, 12.1, 12.2, 12.3, 12.4, 12.5, 13.0, and 13.2:
+
+```bash
+pip install ggml-python \
+  --extra-index-url https://abetlen.github.io/ggml-python/whl/<cuda-version>
+```
+
+Where `<cuda-version>` is one of the following:
+
+- `cu118`: CUDA 11.8
+- `cu121`: CUDA 12.1
+- `cu122`: CUDA 12.2
+- `cu123`: CUDA 12.3
+- `cu124`: CUDA 12.4
+- `cu125`: CUDA 12.5
+- `cu130`: CUDA 13.0
+- `cu132`: CUDA 13.2
+
+For example, to install the CUDA 12.1 wheel:
+
+```bash
+pip install ggml-python \
+  --extra-index-url https://abetlen.github.io/ggml-python/whl/cu121
+```
+
+Pre-built Metal wheels are available for Apple Silicon macOS:
+
+```bash
+pip install ggml-python \
+  --extra-index-url https://abetlen.github.io/ggml-python/whl/metal
+```
+
+When installing from source, pip compiles ggml with CMake and requires a C compiler installed on your system.
 
 Below are the available options for building ggml-python with additional options for optimized inference.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ You can use ggml-python to:
 
 Requirements
 
-- Python 3.7+
+- Python 3.8+
 - C compiler (gcc, clang, msvc, etc)
 
 You can install `ggml-python` using `pip`:
@@ -28,7 +28,10 @@ You can install `ggml-python` using `pip`:
 pip install ggml-python
 ```
 
-This will compile ggml using cmake which requires a c compiler installed on your system.
+Release wheels are tagged `py3-none` and support Python 3.8 through 3.14 when a matching platform wheel is available.
+CUDA release wheel builds track CUDA 11.8, 12.1, 12.2, 12.3, 12.4, 12.5, 13.0, and 13.2.
+
+When installing from source, this will compile ggml using cmake which requires a c compiler installed on your system.
 
 Below are the available options for building ggml-python with additional options for optimized inference.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = { text = "MIT" }
 authors = [
     { name = "Andrei Betlen", email = "abetlen@gmail.com" },
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
     "numpy>=1.20.0",
     "typing_extensions>=4.6.3",
@@ -24,10 +24,13 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 
 [tool.scikit-build]
 wheel.packages = ["ggml"]
+wheel.py-api = "py3"
 wheel.expand-macos-universal-tags = true
 cmake.verbose = true
 cmake.minimum-version = "3.21"


### PR DESCRIPTION
## Summary
- add Python 3.13 and 3.14 classifiers and set scikit-build wheels to `py3-none`
- update CPU, Metal, and CUDA wheel workflows to reduced py3 builder matrices with current runner types
- align CUDA wheel support with llama-cpp-python and add matching wheel index entries
- update README/docs/changelog, including pre-built wheel index install listings for CPU, CUDA, and Metal wheels

## Tests
- `direnv exec . python -m ruff check ggml tests`
- `direnv exec . python -m ruff format --check --exclude ggml/ggml.py ggml tests`
- `direnv exec . python -m pytest`
- `direnv exec . python -m mkdocs build --strict`
- `direnv exec . python -m build --wheel --outdir /tmp/ggml-python-wheel-test`
- YAML/TOML parse check for wheel workflows and `pyproject.toml`

Local wheel tag verified: `ggml_python-0.0.37-py3-none-linux_x86_64.whl`.