### PR TITLE
release: bump version to 0.0.38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,5 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.38] - 2026-06-02
+
 - ci: update pre-built wheels to py3-none and add CUDA 11.8-13.2 support
 - feat: Update ggml to ggml-org/ggml@1e33fed3 and sync Python bindings by @abetlen in #100

--- a/ggml/__init__.py
+++ b/ggml/__init__.py
@@ -1,3 +1,3 @@
 from .ggml import *
 
-__version__ = "0.0.37"
+__version__ = "0.0.38"


### PR DESCRIPTION
## Summary
- bump `ggml-python` package version from `0.0.37` to `0.0.38`
- move the current unreleased changelog entries under a `0.0.38` release heading dated 2026-06-02

## Tests
- `direnv exec . python - <<'PY' ...` confirmed `ggml.__version__ == "0.0.38"`
- `direnv exec . python -m ruff check ggml tests`
- `direnv exec . python -m pytest`
- `direnv exec . python -m mkdocs build --strict`
- `direnv exec . python -m build --wheel --outdir /tmp/ggml-python-0.0.38-wheel-test`

Local wheel verified: `ggml_python-0.0.38-py3-none-linux_x86_64.whl`.