### PR TITLE
ci: add Vulkan wheel builds

### DIFF
--- a/.github/workflows/wheels-index.yaml
+++ b/.github/workflows/wheels-index.yaml
@@ -43,6 +43,7 @@ jobs:
           ./scripts/releases-to-pep-503.sh index/whl/cu125 '^[v]?[0-9]+\.[0-9]+\.[0-9]+-cu125$'
           ./scripts/releases-to-pep-503.sh index/whl/cu130 '^[v]?[0-9]+\.[0-9]+\.[0-9]+-cu130$'
           ./scripts/releases-to-pep-503.sh index/whl/cu132 '^[v]?[0-9]+\.[0-9]+\.[0-9]+-cu132$'
+          ./scripts/releases-to-pep-503.sh index/whl/vulkan '^[v]?[0-9]+\.[0-9]+\.[0-9]+-vulkan$'
           ./scripts/releases-to-pep-503.sh index/whl/metal '^[v]?[0-9]+\.[0-9]+\.[0-9]+-metal$'
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/wheels-vulkan.yaml
+++ b/.github/workflows/wheels-vulkan.yaml
@@ -1,0 +1,119 @@
+name: Wheels Vulkan
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build_wheels:
+    name: Build Vulkan wheel on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            pyver: "3.9"
+            artifact: wheels-vulkan-ubuntu-22.04
+          - os: windows-2022
+            pyver: "3.9"
+            artifact: wheels-vulkan-windows-2022
+
+    steps:
+      - name: Set up MSVC
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+
+      - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.pyver }}
+          cache: "pip"
+
+      - name: Install Vulkan SDK
+        if: runner.os == 'Linux'
+        run: |
+          sudo install -d -m 0755 /etc/apt/keyrings
+          curl -fsSL https://packages.lunarg.com/lunarg-signing-key-pub.asc \
+            | gpg --dearmor \
+            | sudo tee /etc/apt/keyrings/lunarg.gpg > /dev/null
+          echo "deb [signed-by=/etc/apt/keyrings/lunarg.gpg] https://packages.lunarg.com/vulkan jammy main" \
+            | sudo tee /etc/apt/sources.list.d/lunarg-vulkan-jammy.list
+          sudo apt-get update
+          sudo apt-get install -y vulkan-sdk
+          glslc --version
+
+      - name: Install Vulkan SDK
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          choco install vulkan-sdk --no-progress -y
+          $vulkanSdk = Get-ChildItem 'C:\VulkanSDK' -Directory | Sort-Object Name -Descending | Select-Object -First 1
+          if (-not $vulkanSdk) {
+            throw 'Failed to find Vulkan SDK under C:\VulkanSDK'
+          }
+          "VULKAN_SDK=$($vulkanSdk.FullName)" >> $env:GITHUB_ENV
+          "$($vulkanSdk.FullName)\Bin" >> $env:GITHUB_PATH
+          & "$($vulkanSdk.FullName)\Bin\glslc.exe" --version
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build wheel
+
+      - name: Install Windows build dependencies
+        if: runner.os == 'Windows'
+        run: python -m pip install ninja
+
+      - name: Build Vulkan wheel
+        if: runner.os == 'Linux'
+        run: |
+          export CMAKE_ARGS="-DGGML_NATIVE=off -DGGML_METAL=OFF -DGGML_VULKAN=on"
+          python -m build --wheel
+          mkdir -p wheelhouse
+          cp dist/*.whl wheelhouse/
+
+      - name: Build Vulkan wheel
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $env:CMAKE_GENERATOR = 'Ninja'
+          $env:CMAKE_ARGS = '-DGGML_NATIVE=off -DGGML_VULKAN=on'
+          python -m build --wheel
+          New-Item -ItemType Directory -Force wheelhouse | Out-Null
+          Copy-Item dist/*.whl wheelhouse/
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: ./wheelhouse/*.whl
+
+  release:
+    name: Release
+    needs: [build_wheels]
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+          path: dist
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+          # Set release name to <tag>-vulkan.
+          tag_name: ${{ github.ref_name }}-vulkan
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/wheels-vulkan.yaml
+++ b/.github/workflows/wheels-vulkan.yaml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: write
 
+env:
+  VULKAN_SDK_VERSION: "1.4.341.0"
+  VULKAN_SDK_LINUX_SHA256: "ed66477d587a5587dc3601b1c2cdcc1fab5529c505f53a00171876cecd9b4fbe"
+
 jobs:
   build_wheels:
     name: Build Vulkan wheel on ${{ matrix.os }}
@@ -43,28 +47,32 @@ jobs:
       - name: Install Vulkan SDK
         if: runner.os == 'Linux'
         run: |
-          sudo install -d -m 0755 /etc/apt/keyrings
-          curl -fsSL https://packages.lunarg.com/lunarg-signing-key-pub.asc \
-            | gpg --dearmor \
-            | sudo tee /etc/apt/keyrings/lunarg.gpg > /dev/null
-          echo "deb [signed-by=/etc/apt/keyrings/lunarg.gpg] https://packages.lunarg.com/vulkan jammy main" \
-            | sudo tee /etc/apt/sources.list.d/lunarg-vulkan-jammy.list
-          sudo apt-get update
-          sudo apt-get install -y vulkan-sdk
-          glslc --version
+          curl -fL \
+            "https://sdk.lunarg.com/sdk/download/${VULKAN_SDK_VERSION}/linux/vulkansdk-linux-x86_64-${VULKAN_SDK_VERSION}.tar.xz" \
+            -o vulkan-sdk.tar.xz
+          echo "${VULKAN_SDK_LINUX_SHA256}  vulkan-sdk.tar.xz" | sha256sum -c -
+          mkdir -p "$RUNNER_TEMP/vulkan-sdk"
+          tar -xf vulkan-sdk.tar.xz -C "$RUNNER_TEMP/vulkan-sdk"
+          source "$RUNNER_TEMP/vulkan-sdk/${VULKAN_SDK_VERSION}/setup-env.sh"
+          {
+            echo "VULKAN_SDK=$VULKAN_SDK"
+            echo "LD_LIBRARY_PATH=$VULKAN_SDK/lib:${LD_LIBRARY_PATH:-}"
+          } >> "$GITHUB_ENV"
+          echo "$VULKAN_SDK/bin" >> "$GITHUB_PATH"
+          "$VULKAN_SDK/bin/glslc" --version
 
       - name: Install Vulkan SDK
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          choco install vulkan-sdk --no-progress -y
-          $vulkanSdk = Get-ChildItem 'C:\VulkanSDK' -Directory | Sort-Object Name -Descending | Select-Object -First 1
-          if (-not $vulkanSdk) {
-            throw 'Failed to find Vulkan SDK under C:\VulkanSDK'
+          choco install vulkan-sdk --version="$env:VULKAN_SDK_VERSION" --no-progress -y
+          $vulkanSdk = Join-Path 'C:\VulkanSDK' $env:VULKAN_SDK_VERSION
+          if (-not (Test-Path $vulkanSdk)) {
+            throw "Failed to find Vulkan SDK at $vulkanSdk"
           }
-          "VULKAN_SDK=$($vulkanSdk.FullName)" >> $env:GITHUB_ENV
-          "$($vulkanSdk.FullName)\Bin" >> $env:GITHUB_PATH
-          & "$($vulkanSdk.FullName)\Bin\glslc.exe" --version
+          "VULKAN_SDK=$vulkanSdk" >> $env:GITHUB_ENV
+          "$vulkanSdk\Bin" >> $env:GITHUB_PATH
+          & "$vulkanSdk\Bin\glslc.exe" --version
 
       - name: Install build dependencies
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- ci: add Vulkan pre-built wheel support
+- ci: add Vulkan wheel builds by @abetlen in #108
 - feat: add tensor layout helper bindings by @abetlen in #106
 - feat: add ggml_is_contiguous_{0,1,2} by @aisk in #95
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- ci: add Vulkan pre-built wheel support
 - feat: add tensor layout helper bindings by @abetlen in #106
 - feat: add ggml_is_contiguous_{0,1,2} by @aisk in #95
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ pip install ggml-python \
   --extra-index-url https://abetlen.github.io/ggml-python/whl/metal
 ```
 
+Pre-built Vulkan wheels are available for Linux and Windows:
+
+```bash
+pip install ggml-python \
+  --extra-index-url https://abetlen.github.io/ggml-python/whl/vulkan
+```
+
 When installing from source, pip compiles ggml with CMake and requires a C compiler installed on your system.
 To build ggml with specific features (ie. OpenBLAS, GPU Support, etc) you can pass specific cmake options through the `cmake.args` pip install configuration setting. For example to install ggml-python with cuBLAS support you can run:
 
@@ -89,6 +96,7 @@ pip install ggml-python --config-settings=cmake.args='-DGGML_CUDA=ON'
 | `GGML_BLAS` | Enable BLAS support | `OFF` |
 | `GGML_BLAS_VENDOR` | Select BLAS vendor, for example `OpenBLAS` | unset |
 | `GGML_METAL` | Enable Metal support | `OFF` |
+| `GGML_VULKAN` | Enable Vulkan support | `OFF` |
 | `GGML_RPC` | Enable RPC support | `OFF` |
 
 # Usage


### PR DESCRIPTION
- add Vulkan wheel builds for Linux and Windows
- pin the Vulkan SDK to 1.4.341.0 for reproducible builds
- publish tag builds to `<tag>-vulkan`