### PR TITLE
ci: add ROCm and Windows HIP wheel builds

### DIFF
--- a/.github/workflows/wheels-index.yaml
+++ b/.github/workflows/wheels-index.yaml
@@ -44,6 +44,7 @@ jobs:
           ./scripts/releases-to-pep-503.sh index/whl/cu130 '^[v]?[0-9]+\.[0-9]+\.[0-9]+-cu130$'
           ./scripts/releases-to-pep-503.sh index/whl/cu132 '^[v]?[0-9]+\.[0-9]+\.[0-9]+-cu132$'
           ./scripts/releases-to-pep-503.sh index/whl/vulkan '^[v]?[0-9]+\.[0-9]+\.[0-9]+-vulkan$'
+          ./scripts/releases-to-pep-503.sh index/whl/rocm72 '^[v]?[0-9]+\.[0-9]+\.[0-9]+-rocm72$'
           ./scripts/releases-to-pep-503.sh index/whl/metal '^[v]?[0-9]+\.[0-9]+\.[0-9]+-metal$'
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/wheels-index.yaml
+++ b/.github/workflows/wheels-index.yaml
@@ -45,6 +45,7 @@ jobs:
           ./scripts/releases-to-pep-503.sh index/whl/cu132 '^[v]?[0-9]+\.[0-9]+\.[0-9]+-cu132$'
           ./scripts/releases-to-pep-503.sh index/whl/vulkan '^[v]?[0-9]+\.[0-9]+\.[0-9]+-vulkan$'
           ./scripts/releases-to-pep-503.sh index/whl/rocm72 '^[v]?[0-9]+\.[0-9]+\.[0-9]+-rocm72$'
+          ./scripts/releases-to-pep-503.sh index/whl/hip-radeon '^[v]?[0-9]+\.[0-9]+\.[0-9]+-hip-radeon$'
           ./scripts/releases-to-pep-503.sh index/whl/metal '^[v]?[0-9]+\.[0-9]+\.[0-9]+-metal$'
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/wheels-rocm.yaml
+++ b/.github/workflows/wheels-rocm.yaml
@@ -4,9 +4,13 @@ on:
   workflow_dispatch:
     inputs:
       amdgpu_targets:
-        description: AMDGPU targets to compile into the ROCm wheel
+        description: AMDGPU targets to compile into the Linux ROCm wheel
         required: false
         default: gfx908;gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1150;gfx1151;gfx1200;gfx1201
+      windows_amdgpu_targets:
+        description: AMDGPU targets to compile into the Windows HIP Radeon wheel
+        required: false
+        default: gfx1150;gfx1151;gfx1200;gfx1201;gfx1100;gfx1101;gfx1102;gfx1030;gfx1031;gfx1032
   push:
     tags:
       - "v*"
@@ -82,5 +86,142 @@ jobs:
           files: dist/*
           # Set tag_name to <tag>-rocm<rocm_version>.
           tag_name: ${{ github.ref_name }}-rocm${{ env.ROCM_VERSION }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build_wheels_windows_hip:
+    name: Build Wheel windows-2022 ${{ matrix.pyver }} HIP ${{ matrix.name }}
+    runs-on: windows-2022
+    env:
+      HIPSDK_INSTALLER_VERSION: "26.Q1"
+    strategy:
+      matrix:
+        include:
+          - name: radeon
+            pyver: "3.9"
+            amdgpu_targets: gfx1150;gfx1151;gfx1200;gfx1201;gfx1100;gfx1101;gfx1102;gfx1030;gfx1031;gfx1032
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.pyver }}
+          cache: "pip"
+
+      - name: Grab rocWMMA package
+        run: |
+          curl -o rocwmma.deb "https://repo.radeon.com/rocm/apt/7.2.1/pool/main/r/rocwmma-dev/rocwmma-dev_2.2.0.70201-81~24.04_amd64.deb"
+          7z x rocwmma.deb
+          7z x data.tar
+
+      - name: Cache ROCm installation
+        id: cache-rocm
+        uses: actions/cache@v4
+        with:
+          path: C:\Program Files\AMD\ROCm
+          key: cache-gha-rocm-${{ env.HIPSDK_INSTALLER_VERSION }}-${{ runner.os }}
+
+      - name: Install ROCm
+        if: steps.cache-rocm.outputs.cache-hit != 'true'
+        run: |
+          $ErrorActionPreference = "Stop"
+          Write-Host "Downloading AMD HIP SDK installer"
+          Invoke-WebRequest `
+            -Uri "https://download.amd.com/developer/eula/rocm-hub/AMD-Software-PRO-Edition-${{ env.HIPSDK_INSTALLER_VERSION }}-Win11-For-HIP.exe" `
+            -OutFile "${env:RUNNER_TEMP}\rocm-install.exe"
+          Write-Host "Installing AMD HIP SDK"
+          $proc = Start-Process "${env:RUNNER_TEMP}\rocm-install.exe" -ArgumentList '-install' -NoNewWindow -PassThru
+          $completed = $proc.WaitForExit(600000)
+          if (-not $completed) {
+            Write-Error "ROCm installation timed out after 10 minutes"
+            $proc.Kill()
+            exit 1
+          }
+          if ($proc.ExitCode -ne 0) {
+            Write-Error "ROCm installation failed with exit code $($proc.ExitCode)"
+            exit 1
+          }
+
+      - name: Verify ROCm
+        run: |
+          $clangPath = Get-ChildItem 'C:\Program Files\AMD\ROCm\*\bin\clang.exe' | Select-Object -First 1
+          if (-not $clangPath) {
+            Write-Error "ROCm installation not found"
+            exit 1
+          }
+          & $clangPath.FullName --version
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build wheel
+
+      - name: Build wheel
+        env:
+          MATRIX_AMDGPU_TARGETS: ${{ matrix.amdgpu_targets }}
+          INPUT_AMDGPU_TARGETS: ${{ inputs.windows_amdgpu_targets }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          $hipPath = Resolve-Path 'C:\Program Files\AMD\ROCm\*\bin\clang.exe' | Split-Path | Split-Path
+          $rocwmmaInclude = (Join-Path $PWD 'opt\rocm-7.2.1\include').Replace('\', '/')
+          $amdgpuTargets = if ($env:INPUT_AMDGPU_TARGETS) { $env:INPUT_AMDGPU_TARGETS } else { $env:MATRIX_AMDGPU_TARGETS }
+
+          $env:HIP_PATH = $hipPath
+          $env:ROCM_PATH = $hipPath
+          $env:CMAKE_PREFIX_PATH = $hipPath
+          $env:HIP_PLATFORM = 'amd'
+          $env:PATH = "$hipPath\bin;$env:PATH"
+          $env:CC = "$hipPath\bin\clang.exe"
+          $env:CXX = "$hipPath\bin\clang++.exe"
+          $env:HIPCXX = "$hipPath\bin\clang.exe"
+          $env:CMAKE_GENERATOR = 'Unix Makefiles'
+          $env:CXXFLAGS = "-I$rocwmmaInclude -Wno-ignored-attributes -Wno-nested-anon-types"
+          $env:CMAKE_ARGS = "-DGGML_HIP=ON -DGGML_HIP_ROCWMMA_FATTN=ON -DGGML_NATIVE=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGPU_TARGETS=$amdgpuTargets"
+
+          python -m build --wheel
+
+      - name: Bundle ROCm runtime DLLs
+        run: |
+          $ErrorActionPreference = "Stop"
+          $hipPath = Resolve-Path 'C:\Program Files\AMD\ROCm\*\bin\clang.exe' | Split-Path | Split-Path
+          $wheel = Get-ChildItem dist\*.whl | Select-Object -First 1
+          python -m wheel unpack $wheel.FullName -d wheel-unpacked
+          $wheelRoot = Get-ChildItem wheel-unpacked -Directory | Select-Object -First 1
+          $libDir = Join-Path $wheelRoot.FullName 'ggml\lib'
+          New-Item -ItemType Directory -Force $libDir | Out-Null
+
+          $dllPatterns = @(
+            'amdhip64.dll',
+            'hiprtc*.dll',
+            'libhipblas.dll',
+            'libhipblaslt.dll',
+            'rocblas.dll'
+          )
+          foreach ($pattern in $dllPatterns) {
+            Copy-Item (Join-Path $hipPath "bin\$pattern") $libDir -ErrorAction SilentlyContinue
+          }
+
+          New-Item -ItemType Directory -Force (Join-Path $libDir 'rocblas\library') | Out-Null
+          New-Item -ItemType Directory -Force (Join-Path $libDir 'hipblaslt\library') | Out-Null
+          Copy-Item "$hipPath\bin\rocblas\library\*" (Join-Path $libDir 'rocblas\library') -Recurse -Force
+          Copy-Item "$hipPath\bin\hipblaslt\library\*" (Join-Path $libDir 'hipblaslt\library') -Recurse -Force
+
+          Remove-Item dist\*.whl
+          python -m wheel pack $wheelRoot.FullName -d dist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-hip-${{ matrix.name }}-windows-2022
+          path: dist/*.whl
+
+      - uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: dist/*
+          # Set tag_name to <tag>-hip-radeon.
+          tag_name: ${{ github.ref_name }}-hip-${{ matrix.name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/wheels-rocm.yaml
+++ b/.github/workflows/wheels-rocm.yaml
@@ -6,7 +6,7 @@ on:
       amdgpu_targets:
         description: AMDGPU targets to compile into the ROCm wheel
         required: false
-        default: gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102
+        default: gfx908;gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1150;gfx1151;gfx1200;gfx1201
   push:
     tags:
       - "v*"
@@ -26,7 +26,7 @@ jobs:
           - os: ubuntu-22.04
             pyver: "3.9"
             rocm: "7.2.4"
-            amdgpu_targets: gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102
+            amdgpu_targets: gfx908;gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1150;gfx1151;gfx1200;gfx1201
 
     steps:
       - name: Install system dependencies

--- a/.github/workflows/wheels-rocm.yaml
+++ b/.github/workflows/wheels-rocm.yaml
@@ -1,0 +1,86 @@
+name: Wheels ROCm
+
+on:
+  workflow_dispatch:
+    inputs:
+      amdgpu_targets:
+        description: AMDGPU targets to compile into the ROCm wheel
+        required: false
+        default: gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build_wheels:
+    name: Build Wheel ${{ matrix.os }} ${{ matrix.pyver }} ROCm ${{ matrix.rocm }}
+    runs-on: ${{ matrix.os }}
+    container:
+      image: rocm/dev-ubuntu-22.04:${{ matrix.rocm }}-complete
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            pyver: "3.9"
+            rocm: "7.2.4"
+            amdgpu_targets: gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102
+
+    steps:
+      - name: Install system dependencies
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends git cmake lsb-release ninja-build
+
+      - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.pyver }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build wheel
+
+      - name: Build wheel
+        env:
+          MATRIX_AMDGPU_TARGETS: ${{ matrix.amdgpu_targets }}
+          INPUT_AMDGPU_TARGETS: ${{ inputs.amdgpu_targets }}
+        run: |
+          export ROCM_PATH="${ROCM_PATH:-/opt/rocm}"
+          export HIP_PATH="${HIP_PATH:-$ROCM_PATH}"
+          export PATH="$ROCM_PATH/bin:$ROCM_PATH/llvm/bin:$PATH"
+          export LD_LIBRARY_PATH="$ROCM_PATH/lib:$ROCM_PATH/lib64:${LD_LIBRARY_PATH:-}"
+          export CC="$ROCM_PATH/llvm/bin/clang"
+          export CXX="$ROCM_PATH/llvm/bin/clang++"
+          export HIPCXX="$ROCM_PATH/llvm/bin/clang"
+          export CMAKE_GENERATOR=Ninja
+
+          hipconfig --version
+          hipcc --version
+
+          rocm_tag="$(hipconfig --version | sed -E 's/^([0-9]+)\.([0-9]+).*/\1\2/')"
+          echo "ROCM_VERSION=$rocm_tag" >> "$GITHUB_ENV"
+
+          amdgpu_targets="${INPUT_AMDGPU_TARGETS:-$MATRIX_AMDGPU_TARGETS}"
+          export CMAKE_ARGS="-DGGML_HIP=on -DGGML_NATIVE=off -DGGML_AVX=off -DGGML_AVX2=off -DGGML_FMA=off -DGGML_F16C=off -DAMDGPU_TARGETS=$amdgpu_targets -DCMAKE_HIP_ARCHITECTURES=$amdgpu_targets"
+          python -m build --wheel
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-rocm${{ env.ROCM_VERSION }}-${{ matrix.os }}
+          path: dist/*.whl
+
+      - uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: dist/*
+          # Set tag_name to <tag>-rocm<rocm_version>.
+          tag_name: ${{ github.ref_name }}-rocm${{ env.ROCM_VERSION }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - ci: add Vulkan wheel builds by @abetlen in #108
-- ci: add ROCm pre-built wheel builds
+- ci: add ROCm wheel builds by @abetlen in #109
 - feat: add tensor layout helper bindings by @abetlen in #106
 - feat: add ggml_is_contiguous_{0,1,2} by @aisk in #95
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - ci: add Vulkan wheel builds by @abetlen in #108
-- ci: add ROCm wheel builds by @abetlen in #109
+- ci: add ROCm and Windows HIP wheel builds by @abetlen in #109
 - feat: add tensor layout helper bindings by @abetlen in #106
 - feat: add ggml_is_contiguous_{0,1,2} by @aisk in #95
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - ci: add Vulkan wheel builds by @abetlen in #108
+- ci: add ROCm pre-built wheel builds
 - feat: add tensor layout helper bindings by @abetlen in #106
 - feat: add ggml_is_contiguous_{0,1,2} by @aisk in #95
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,13 @@ pip install ggml-python \
   --extra-index-url https://abetlen.github.io/ggml-python/whl/vulkan
 ```
 
+Pre-built ROCm wheels are available for Linux x86_64 with ROCm 7.2:
+
+```bash
+pip install ggml-python \
+  --extra-index-url https://abetlen.github.io/ggml-python/whl/rocm72
+```
+
 When installing from source, pip compiles ggml with CMake and requires a C compiler installed on your system.
 To build ggml with specific features (ie. OpenBLAS, GPU Support, etc) you can pass specific cmake options through the `cmake.args` pip install configuration setting. For example to install ggml-python with cuBLAS support you can run:
 
@@ -92,6 +99,7 @@ pip install ggml-python --config-settings=cmake.args='-DGGML_CUDA=ON'
 | Option | Description | Default |
 | --- | --- | --- |
 | `GGML_CUDA` | Enable cuBLAS support | `OFF` |
+| `GGML_HIP` | Enable HIP / ROCm support | `OFF` |
 | `GGML_OPENCL` | Enable OpenCL support | `OFF` |
 | `GGML_BLAS` | Enable BLAS support | `OFF` |
 | `GGML_BLAS_VENDOR` | Select BLAS vendor, for example `OpenBLAS` | unset |

--- a/README.md
+++ b/README.md
@@ -86,6 +86,13 @@ pip install ggml-python \
   --extra-index-url https://abetlen.github.io/ggml-python/whl/rocm72
 ```
 
+Pre-built HIP Radeon wheels are available for Windows x86_64:
+
+```bash
+pip install ggml-python \
+  --extra-index-url https://abetlen.github.io/ggml-python/whl/hip-radeon
+```
+
 When installing from source, pip compiles ggml with CMake and requires a C compiler installed on your system.
 To build ggml with specific features (ie. OpenBLAS, GPU Support, etc) you can pass specific cmake options through the `cmake.args` pip install configuration setting. For example to install ggml-python with cuBLAS support you can run:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ title: Getting Started
 ggml-python is a python library for working with [ggml](https://github.com/ggml-org/ggml).
 
 ggml is a tensor library for machine learning developed by Georgi Gerganov, the library has been used to run models like Whisper and LLaMa on a wide range of devices.
-ggml is written in C/C++ and is designed to be fast, portable and easily embeddable; making use of various hardware acceleration systems like BLAS, CUDA, OpenCL, and Metal.
+ggml is written in C/C++ and is designed to be fast, portable and easily embeddable; making use of various hardware acceleration systems like BLAS, CUDA, HIP / ROCm, OpenCL, and Metal.
 ggml supports quantized inference for reduced memory footprint and faster inference.
 
 You can use ggml-python to:
@@ -69,6 +69,13 @@ pip install ggml-python \
   --extra-index-url https://abetlen.github.io/ggml-python/whl/metal
 ```
 
+Pre-built ROCm wheels are available for Linux x86_64 with ROCm 7.2:
+
+```bash
+pip install ggml-python \
+  --extra-index-url https://abetlen.github.io/ggml-python/whl/rocm72
+```
+
 When installing from source, pip compiles ggml with CMake and requires a C compiler installed on your system.
 
 Below are the available options for building ggml-python with additional options for optimized inference.
@@ -83,6 +90,12 @@ Below are the available options for building ggml-python with additional options
 
     ```bash
     CMAKE_ARGS="-DGGML_CUDA=ON" pip install ggml-python
+    ```
+
+=== "**HIP / ROCm**"
+
+    ```bash
+    CMAKE_ARGS="-DGGML_HIP=ON" pip install ggml-python
     ```
 
 === "**Metal**"

--- a/docs/index.md
+++ b/docs/index.md
@@ -76,6 +76,13 @@ pip install ggml-python \
   --extra-index-url https://abetlen.github.io/ggml-python/whl/rocm72
 ```
 
+Pre-built HIP Radeon wheels are available for Windows x86_64:
+
+```bash
+pip install ggml-python \
+  --extra-index-url https://abetlen.github.io/ggml-python/whl/hip-radeon
+```
+
 When installing from source, pip compiles ggml with CMake and requires a C compiler installed on your system.
 
 Below are the available options for building ggml-python with additional options for optimized inference.


### PR DESCRIPTION
## Summary

- Add Linux x86_64 ROCm wheel builds using the ROCm 7.2.4 complete container.
- Add a separate Windows x86_64 HIP Radeon wheel job in the same ROCm workflow using AMD HIP SDK 26.Q1.
- Publish Linux ROCm wheels under `<tag>-rocm72` and Windows HIP wheels under `<tag>-hip-radeon`.
- Document the ROCm and HIP Radeon wheel extra-index URLs.
- Align the Linux and Windows AMDGPU target lists with upstream llama.cpp release coverage.

## Validation

- `git diff --check`
- YAML parse for `.github/workflows/wheels-rocm.yaml` and `.github/workflows/wheels-index.yaml`
- `mkdocs build --strict` with the main repo direnv environment
- Workflow dispatch on `ci/add-rocm-wheels` with narrowed targets (`gfx1030` Linux ROCm, `gfx1100` Windows HIP Radeon): https://github.com/abetlen/ggml-python/actions/runs/26812787677
  - Uploaded `wheels-rocm72-ubuntu-22.04`
  - Uploaded `wheels-hip-radeon-windows-2022`
