### PR TITLE
ci: increase Windows HIP installer timeout

### DIFF
--- a/.github/workflows/wheels-rocm.yaml
+++ b/.github/workflows/wheels-rocm.yaml
@@ -134,9 +134,9 @@ jobs:
             -OutFile "${env:RUNNER_TEMP}\rocm-install.exe"
           Write-Host "Installing AMD HIP SDK"
           $proc = Start-Process "${env:RUNNER_TEMP}\rocm-install.exe" -ArgumentList '-install' -NoNewWindow -PassThru
-          $completed = $proc.WaitForExit(600000)
+          $completed = $proc.WaitForExit(1800000)
           if (-not $completed) {
-            Write-Error "ROCm installation timed out after 10 minutes"
+            Write-Error "ROCm installation timed out after 30 minutes"
             $proc.Kill()
             exit 1
           }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- ci: increase Windows HIP SDK installer timeout by @abetlen in #112
+
 ## [0.0.39]
 
 - ci: add Vulkan wheel builds by @abetlen in #108


### PR DESCRIPTION
Increase the Windows HIP SDK installer wait from 10 minutes to 30 minutes in the ROCm wheel workflow.