### PR TITLE
ci: add tag triggers for release publishing workflows

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,7 +2,12 @@ name: Publish
 
 # Based on: https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*.*.*"
+      - "!v*.*.*-*"
 
 jobs:
   build-n-publish:
@@ -25,8 +30,6 @@ jobs:
       run: |
         python3 -m build --sdist
     - name: Publish distribution to PyPI
-      # TODO: move to tag based releases
-      # if: startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/wheels-cuda.yaml
+++ b/.github/workflows/wheels-cuda.yaml
@@ -1,6 +1,11 @@
 name: Wheels CUDA
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*.*.*"
+      - "!v*.*.*-*"
 
 permissions:
   contents: write

--- a/.github/workflows/wheels-metal.yaml
+++ b/.github/workflows/wheels-metal.yaml
@@ -1,6 +1,11 @@
 name: Wheels Metal
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*.*.*"
+      - "!v*.*.*-*"
 
 permissions:
   contents: write

--- a/.github/workflows/wheels-rocm.yaml
+++ b/.github/workflows/wheels-rocm.yaml
@@ -13,7 +13,8 @@ on:
         default: gfx1150;gfx1151;gfx1200;gfx1201;gfx1100;gfx1101;gfx1102;gfx1030;gfx1031;gfx1032
   push:
     tags:
-      - "v*"
+      - "v*.*.*"
+      - "!v*.*.*-*"
 
 permissions:
   contents: write

--- a/.github/workflows/wheels-vulkan.yaml
+++ b/.github/workflows/wheels-vulkan.yaml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*.*.*"
+      - "!v*.*.*-*"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -1,6 +1,11 @@
 name: Wheels
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*.*.*"
+      - "!v*.*.*-*"
 
 permissions:
   contents: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - ci: increase Windows HIP SDK installer timeout by @abetlen in #112
+- ci: add tag triggers for release publishing workflows by @abetlen in #113
 
 ## [0.0.39]
 


### PR DESCRIPTION
## Summary
- trigger PyPI publishing, CPU wheels, CUDA wheels, and Metal wheels from canonical release tags
- keep workflow dispatch support for manual runs
- tighten Vulkan and ROCm tag filters so derived wheel-release tags do not retrigger release builds

## Tests
- `git diff --check`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/publish.yaml .github/workflows/wheels.yaml .github/workflows/wheels-cuda.yaml .github/workflows/wheels-metal.yaml .github/workflows/wheels-vulkan.yaml .github/workflows/wheels-rocm.yaml`