### PR TITLE
feat: add CUDA backend bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - feat: add missing ggml.h bindings by @abetlen in #118
+- feat: add CUDA backend bindings by @abetlen in #119
 - feat: add arithmetic op bindings by @aisk in #114
 - fix: detect current optional backend symbols by @abetlen in #117
 - ci: increase Windows HIP SDK installer timeout by @abetlen in #112

--- a/ggml/ggml.py
+++ b/ggml/ggml.py
@@ -14095,6 +14095,7 @@ def ggml_backend_register(
 
 
 GGML_USE_CUDA = hasattr(lib, "ggml_backend_cuda_init")
+GGML_USE_CUDA_LOG_CALLBACK = hasattr(lib, "ggml_backend_cuda_log_set_callback")
 
 
 GGML_CUDA_MAX_DEVICES = 16
@@ -14137,14 +14138,35 @@ def ggml_backend_cuda_buffer_type(
 
 
 # // split tensor buffer that splits matrices by rows across multiple devices
-# GGML_API GGML_CALL ggml_backend_buffer_type_t ggml_backend_cuda_split_buffer_type(const float * tensor_split);
+# GGML_API GGML_CALL bool ggml_backend_cuda_allreduce_tensor(ggml_backend_t * backends, struct ggml_tensor ** tensors, size_t n_backends);
+@ggml_function(
+    "ggml_backend_cuda_allreduce_tensor",
+    [
+        ctypes.POINTER(ggml_backend_t_ctypes),
+        ctypes.POINTER(ctypes.POINTER(ggml_tensor)),
+        ctypes.c_size_t,
+    ],
+    ctypes.c_bool,
+    enabled=GGML_USE_CUDA,
+)
+def ggml_backend_cuda_allreduce_tensor(
+    backends: CtypesPointer[ggml_backend_t_ctypes],
+    tensors: CtypesPointer[ggml_tensor_p],
+    n_backends: Union[ctypes.c_size_t, int],
+    /,
+) -> bool:
+    ...
+
+
+# GGML_API GGML_CALL ggml_backend_buffer_type_t ggml_backend_cuda_split_buffer_type(int main_device, const float * tensor_split);
 @ggml_function(
     "ggml_backend_cuda_split_buffer_type",
-    [ctypes.POINTER(ctypes.c_float)],
+    [ctypes.c_int, ctypes.POINTER(ctypes.c_float)],
     ggml_backend_buffer_type_t_ctypes,
     enabled=GGML_USE_CUDA,
 )
 def ggml_backend_cuda_split_buffer_type(
+    main_device: Union[ctypes.c_int, int],
     tensor_split: CtypesArray[ctypes.c_float],
 ) -> Optional[ggml_backend_buffer_type_t]:
     ...
@@ -14242,6 +14264,17 @@ def ggml_backend_cuda_unregister_host_buffer(
     ...
 
 
+# GGML_API GGML_CALL ggml_backend_reg_t ggml_backend_cuda_reg(void);
+@ggml_function(
+    "ggml_backend_cuda_reg",
+    [],
+    ggml_backend_reg_t_ctypes,
+    enabled=GGML_USE_CUDA,
+)
+def ggml_backend_cuda_reg() -> Optional[ggml_backend_reg_t]:
+    ...
+
+
 # GGML_API void ggml_backend_cuda_log_set_callback(ggml_log_callback log_callback, void * user_data);
 @ggml_function(
     "ggml_backend_cuda_log_set_callback",
@@ -14250,7 +14283,7 @@ def ggml_backend_cuda_unregister_host_buffer(
         ctypes.c_void_p,
     ],
     None,
-    enabled=GGML_USE_CUDA,
+    enabled=GGML_USE_CUDA_LOG_CALLBACK,
 )
 def ggml_backend_cuda_log_set_callback(
     log_callback, user_data: Union[ctypes.c_void_p, int, None], /  # type: ignore

--- a/tests/test_ggml.py
+++ b/tests/test_ggml.py
@@ -74,6 +74,9 @@ def test_ggml_pythonic():
 
 def test_ggml_backend_feature_flags_match_exported_symbols():
     assert ggml.GGML_USE_CUDA == hasattr(ggml.lib, "ggml_backend_cuda_init")
+    assert ggml.GGML_USE_CUDA_LOG_CALLBACK == hasattr(
+        ggml.lib, "ggml_backend_cuda_log_set_callback"
+    )
     assert ggml.GGML_USE_METAL == hasattr(ggml.lib, "ggml_backend_metal_init")
     assert ggml.GGML_USE_OPENCL == hasattr(ggml.lib, "ggml_backend_opencl_init")
     assert ggml.GGML_USE_CLBLAST == hasattr(ggml.lib, "ggml_cl_init")

--- a/tests/test_ggml.py
+++ b/tests/test_ggml.py
@@ -74,9 +74,6 @@ def test_ggml_pythonic():
 
 def test_ggml_backend_feature_flags_match_exported_symbols():
     assert ggml.GGML_USE_CUDA == hasattr(ggml.lib, "ggml_backend_cuda_init")
-    assert ggml.GGML_USE_CUDA_LOG_CALLBACK == hasattr(
-        ggml.lib, "ggml_backend_cuda_log_set_callback"
-    )
     assert ggml.GGML_USE_METAL == hasattr(ggml.lib, "ggml_backend_metal_init")
     assert ggml.GGML_USE_OPENCL == hasattr(ggml.lib, "ggml_backend_opencl_init")
     assert ggml.GGML_USE_CLBLAST == hasattr(ggml.lib, "ggml_cl_init")


### PR DESCRIPTION
Adds missing CUDA backend bindings.

- Adds CUDA allreduce tensor and backend registry wrappers.
- Updates split buffer type to include the main device argument.
- Gates the legacy CUDA log callback wrapper on its own symbol.