### PR TITLE
feat: add RPC backend bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - feat: add missing ggml.h bindings by @abetlen in #118
 - feat: add CUDA backend bindings by @abetlen in #119
+- feat: add RPC backend bindings by @abetlen in #120
 - feat: add arithmetic op bindings by @aisk in #114
 - fix: detect current optional backend symbols by @abetlen in #117
 - ci: increase Windows HIP SDK installer timeout by @abetlen in #112

--- a/ggml/ggml.py
+++ b/ggml/ggml.py
@@ -14791,6 +14791,7 @@ def ggml_backend_vk_host_buffer_type() -> Optional[ggml_backend_buffer_type_t]:
 
 
 GGML_USE_RPC = hasattr(lib, "ggml_backend_rpc_init")
+GGML_USE_RPC_LEGACY_SERVER = hasattr(lib, "start_rpc_server")
 
 
 #define GGML_RPC_MAX_SERVERS       16
@@ -14798,14 +14799,18 @@ GGML_RPC_MAX_SERVERS = 16
 
 
 # // backend API
-# GGML_API GGML_CALL ggml_backend_t ggml_backend_rpc_init(const char * endpoint);
+# GGML_API GGML_CALL ggml_backend_t ggml_backend_rpc_init(const char * endpoint, uint32_t device);
 @ggml_function(
     "ggml_backend_rpc_init",
-    [ctypes.c_char_p],
+    [ctypes.c_char_p, ctypes.c_uint32],
     ggml_backend_t_ctypes,
     enabled=GGML_USE_RPC,
 )
-def ggml_backend_rpc_init(endpoint: bytes) -> Optional[ggml_backend_t]:
+def ggml_backend_rpc_init(
+    endpoint: bytes,
+    device: Union[ctypes.c_uint32, int],
+    /,
+) -> Optional[ggml_backend_t]:
     ...
 
 
@@ -14820,22 +14825,27 @@ def ggml_backend_is_rpc(backend: Union[ggml_backend_t, int], /) -> bool:
     ...
 
 
-# GGML_API GGML_CALL ggml_backend_buffer_type_t ggml_backend_rpc_buffer_type(const char * endpoint);
+# GGML_API GGML_CALL ggml_backend_buffer_type_t ggml_backend_rpc_buffer_type(const char * endpoint, uint32_t device);
 @ggml_function(
     "ggml_backend_rpc_buffer_type",
-    [ctypes.c_char_p],
+    [ctypes.c_char_p, ctypes.c_uint32],
     ggml_backend_buffer_type_t_ctypes,
     enabled=GGML_USE_RPC,
 )
-def ggml_backend_rpc_buffer_type(endpoint: bytes) -> Optional[ggml_backend_buffer_type_t]:
+def ggml_backend_rpc_buffer_type(
+    endpoint: bytes,
+    device: Union[ctypes.c_uint32, int],
+    /,
+) -> Optional[ggml_backend_buffer_type_t]:
     ...
 
 
-# GGML_API GGML_CALL void ggml_backend_rpc_get_device_memory(const char * endpoint, size_t * free, size_t * total);
+# GGML_API GGML_CALL void ggml_backend_rpc_get_device_memory(const char * endpoint, uint32_t device, size_t * free, size_t * total);
 @ggml_function(
     "ggml_backend_rpc_get_device_memory",
     [
         ctypes.c_char_p,
+        ctypes.c_uint32,
         ctypes.POINTER(ctypes.c_size_t),
         ctypes.POINTER(ctypes.c_size_t),
     ],
@@ -14844,11 +14854,64 @@ def ggml_backend_rpc_buffer_type(endpoint: bytes) -> Optional[ggml_backend_buffe
 )
 def ggml_backend_rpc_get_device_memory(
     endpoint: bytes,
+    device: Union[ctypes.c_uint32, int],
     free: CtypesPointer[ctypes.c_size_t],
     total: CtypesPointer[ctypes.c_size_t],
     /,
 ):
     ...
+
+
+# GGML_API GGML_CALL void ggml_backend_rpc_start_server(
+#         const char * endpoint,
+#         const char * cache_dir,
+#         size_t n_threads,
+#         size_t n_devices,
+#         ggml_backend_dev_t * devices);
+@ggml_function(
+    "ggml_backend_rpc_start_server",
+    [
+        ctypes.c_char_p,
+        ctypes.c_char_p,
+        ctypes.c_size_t,
+        ctypes.c_size_t,
+        ctypes.POINTER(ggml_backend_dev_t_ctypes),
+    ],
+    None,
+    enabled=GGML_USE_RPC,
+)
+def ggml_backend_rpc_start_server(
+    endpoint: bytes,
+    cache_dir: Optional[bytes],
+    n_threads: Union[ctypes.c_size_t, int],
+    n_devices: Union[ctypes.c_size_t, int],
+    devices: CtypesPointer[ggml_backend_dev_t_ctypes],
+    /,
+):
+    ...
+
+
+# GGML_API GGML_CALL ggml_backend_reg_t ggml_backend_rpc_reg(void);
+@ggml_function(
+    "ggml_backend_rpc_reg",
+    [],
+    ggml_backend_reg_t_ctypes,
+    enabled=GGML_USE_RPC,
+)
+def ggml_backend_rpc_reg() -> Optional[ggml_backend_reg_t]:
+    ...
+
+
+# GGML_API GGML_CALL ggml_backend_reg_t ggml_backend_rpc_add_server(const char * endpoint);
+@ggml_function(
+    "ggml_backend_rpc_add_server",
+    [ctypes.c_char_p],
+    ggml_backend_reg_t_ctypes,
+    enabled=GGML_USE_RPC,
+)
+def ggml_backend_rpc_add_server(endpoint: bytes, /) -> Optional[ggml_backend_reg_t]:
+    ...
+
 
 # GGML_API GGML_CALL void start_rpc_server(ggml_backend_t backend, const char * endpoint, size_t free_mem, size_t total_mem);
 @ggml_function(
@@ -14860,7 +14923,7 @@ def ggml_backend_rpc_get_device_memory(
         ctypes.c_size_t,
     ],
     None,
-    enabled=GGML_USE_RPC,
+    enabled=GGML_USE_RPC_LEGACY_SERVER,
 )
 def start_rpc_server(
     backend: Union[ggml_backend_t, int],

--- a/tests/test_ggml.py
+++ b/tests/test_ggml.py
@@ -82,6 +82,7 @@ def test_ggml_backend_feature_flags_match_exported_symbols():
         ggml.lib, "ggml_vk_init_cpu_assist"
     )
     assert ggml.GGML_USE_RPC == hasattr(ggml.lib, "ggml_backend_rpc_init")
+    assert ggml.GGML_USE_RPC_LEGACY_SERVER == hasattr(ggml.lib, "start_rpc_server")
 
 
 def test_ggml_custom_op():

--- a/tests/test_ggml.py
+++ b/tests/test_ggml.py
@@ -82,7 +82,6 @@ def test_ggml_backend_feature_flags_match_exported_symbols():
         ggml.lib, "ggml_vk_init_cpu_assist"
     )
     assert ggml.GGML_USE_RPC == hasattr(ggml.lib, "ggml_backend_rpc_init")
-    assert ggml.GGML_USE_RPC_LEGACY_SERVER == hasattr(ggml.lib, "start_rpc_server")
 
 
 def test_ggml_custom_op():


### PR DESCRIPTION
Adds current RPC backend bindings.

- Updates RPC init, buffer type, and memory query signatures to include the device argument.
- Adds RPC server, registry, and add-server wrappers.
- Gates the legacy start_rpc_server wrapper on its own symbol.