### PR TITLE
feat: add Vulkan backend registry binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: add missing ggml.h bindings by @abetlen in #118
 - feat: add CUDA backend bindings by @abetlen in #119
 - feat: add RPC backend bindings by @abetlen in #120
+- feat: add Vulkan backend registry binding by @abetlen in #121
 - feat: add arithmetic op bindings by @aisk in #114
 - fix: detect current optional backend symbols by @abetlen in #117
 - ci: increase Windows HIP SDK installer timeout by @abetlen in #112

--- a/ggml/ggml.py
+++ b/ggml/ggml.py
@@ -14784,6 +14784,17 @@ def ggml_backend_vk_host_buffer_type() -> Optional[ggml_backend_buffer_type_t]:
     ...
 
 
+# GGML_API GGML_CALL ggml_backend_reg_t ggml_backend_vk_reg(void);
+@ggml_function(
+    "ggml_backend_vk_reg",
+    [],
+    ggml_backend_reg_t_ctypes,
+    enabled=GGML_USE_VULKAN,
+)
+def ggml_backend_vk_reg() -> Optional[ggml_backend_reg_t]:
+    ...
+
+
 #####################################################
 # GGML Vulkan API
 # source: src/ggml-rpc.h


### PR DESCRIPTION
Adds the missing Vulkan backend registry binding.

- Adds ggml_backend_vk_reg.
- Keeps the existing Vulkan feature gate.