### PR TITLE
feat: add Hexagon backend bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: add CANN backend bindings by @abetlen in #123
 - feat: add SYCL backend bindings by @abetlen in #124
 - feat: add OpenVINO backend bindings by @abetlen in #125
+- feat: add Hexagon backend bindings by @abetlen in #126
 - feat: add arithmetic op bindings by @aisk in #114
 - fix: detect current optional backend symbols by @abetlen in #117
 - ci: increase Windows HIP SDK installer timeout by @abetlen in #112

--- a/ggml/ggml.py
+++ b/ggml/ggml.py
@@ -14568,6 +14568,48 @@ def ggml_backend_openvino_reg() -> Optional[ggml_backend_reg_t]:
 
 
 #####################################################
+# GGML Hexagon API
+# source: src/ggml-hexagon.h
+#####################################################
+
+
+GGML_USE_HEXAGON = hasattr(lib, "ggml_backend_hexagon_init")
+
+
+# GGML_API GGML_CALL ggml_backend_t ggml_backend_hexagon_init(void);
+@ggml_function(
+    "ggml_backend_hexagon_init",
+    [],
+    ggml_backend_t_ctypes,
+    enabled=GGML_USE_HEXAGON,
+)
+def ggml_backend_hexagon_init() -> Optional[ggml_backend_t]:
+    ...
+
+
+# GGML_API GGML_CALL bool ggml_backend_is_hexagon(ggml_backend_t backend);
+@ggml_function(
+    "ggml_backend_is_hexagon",
+    [ggml_backend_t_ctypes],
+    ctypes.c_bool,
+    enabled=GGML_USE_HEXAGON,
+)
+def ggml_backend_is_hexagon(backend: Union[ggml_backend_t, int], /) -> bool:
+    ...
+
+
+# GGML_API GGML_CALL ggml_backend_reg_t ggml_backend_hexagon_reg(void);
+@ggml_function(
+    "ggml_backend_hexagon_reg",
+    [],
+    ggml_backend_reg_t_ctypes,
+    enabled=GGML_USE_HEXAGON,
+)
+def ggml_backend_hexagon_reg() -> Optional[ggml_backend_reg_t]:
+    ...
+
+
+#####################################################
 # GGML CUDA API
 # source: src/ggml-cuda.h
 #####################################################

--- a/tests/test_ggml.py
+++ b/tests/test_ggml.py
@@ -74,7 +74,6 @@ def test_ggml_pythonic():
 
 def test_ggml_backend_feature_flags_match_exported_symbols():
     assert ggml.GGML_USE_CUDA == hasattr(ggml.lib, "ggml_backend_cuda_init")
-    assert ggml.GGML_USE_HEXAGON == hasattr(ggml.lib, "ggml_backend_hexagon_init")
     assert ggml.GGML_USE_METAL == hasattr(ggml.lib, "ggml_backend_metal_init")
     assert ggml.GGML_USE_OPENCL == hasattr(ggml.lib, "ggml_backend_opencl_init")
     assert ggml.GGML_USE_CLBLAST == hasattr(ggml.lib, "ggml_cl_init")

--- a/tests/test_ggml.py
+++ b/tests/test_ggml.py
@@ -74,6 +74,7 @@ def test_ggml_pythonic():
 
 def test_ggml_backend_feature_flags_match_exported_symbols():
     assert ggml.GGML_USE_CUDA == hasattr(ggml.lib, "ggml_backend_cuda_init")
+    assert ggml.GGML_USE_HEXAGON == hasattr(ggml.lib, "ggml_backend_hexagon_init")
     assert ggml.GGML_USE_METAL == hasattr(ggml.lib, "ggml_backend_metal_init")
     assert ggml.GGML_USE_OPENCL == hasattr(ggml.lib, "ggml_backend_opencl_init")
     assert ggml.GGML_USE_CLBLAST == hasattr(ggml.lib, "ggml_cl_init")


### PR DESCRIPTION
Adds Hexagon backend bindings.

- Adds Hexagon backend init, type check, and registry wrappers.
- Adds a Hexagon feature flag assertion.