### PR TITLE
feat: add CPU conversion bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: add WebGPU backend bindings by @abetlen in #127
 - feat: add ZenDNN backend bindings by @abetlen in #128
 - feat: add zDNN backend bindings by @abetlen in #129
+- feat: add CPU conversion bindings by @abetlen in #130
 - feat: add arithmetic op bindings by @aisk in #114
 - fix: detect current optional backend symbols by @abetlen in #117
 - ci: increase Windows HIP SDK installer timeout by @abetlen in #112

--- a/ggml/ggml.py
+++ b/ggml/ggml.py
@@ -11883,6 +11883,120 @@ def ggml_cpu_init():
     ...
 
 
+# GGML_BACKEND_API void ggml_cpu_fp32_to_fp32(const float * x, float * y, int64_t k);
+@ggml_function(
+    "ggml_cpu_fp32_to_fp32",
+    [
+        ctypes.POINTER(ctypes.c_float),
+        ctypes.POINTER(ctypes.c_float),
+        ctypes.c_int64,
+    ],
+    None,
+)
+def ggml_cpu_fp32_to_fp32(
+    x: CtypesPointer[ctypes.c_float],
+    y: CtypesPointer[ctypes.c_float],
+    k: Union[ctypes.c_int64, int],
+    /,
+) -> None:
+    ...
+
+
+# GGML_BACKEND_API void ggml_cpu_fp32_to_i32(const float * x, int32_t * y, int64_t k);
+@ggml_function(
+    "ggml_cpu_fp32_to_i32",
+    [
+        ctypes.POINTER(ctypes.c_float),
+        ctypes.POINTER(ctypes.c_int32),
+        ctypes.c_int64,
+    ],
+    None,
+)
+def ggml_cpu_fp32_to_i32(
+    x: CtypesPointer[ctypes.c_float],
+    y: CtypesPointer[ctypes.c_int32],
+    k: Union[ctypes.c_int64, int],
+    /,
+) -> None:
+    ...
+
+
+# GGML_BACKEND_API void ggml_cpu_fp32_to_fp16(const float * x, ggml_fp16_t * y, int64_t k);
+@ggml_function(
+    "ggml_cpu_fp32_to_fp16",
+    [
+        ctypes.POINTER(ctypes.c_float),
+        ctypes.POINTER(ggml_fp16_t),
+        ctypes.c_int64,
+    ],
+    None,
+)
+def ggml_cpu_fp32_to_fp16(
+    x: CtypesPointer[ctypes.c_float],
+    y: CtypesPointer[ggml_fp16_t],
+    k: Union[ctypes.c_int64, int],
+    /,
+) -> None:
+    ...
+
+
+# GGML_BACKEND_API void ggml_cpu_fp16_to_fp32(const ggml_fp16_t * x, float * y, int64_t k);
+@ggml_function(
+    "ggml_cpu_fp16_to_fp32",
+    [
+        ctypes.POINTER(ggml_fp16_t),
+        ctypes.POINTER(ctypes.c_float),
+        ctypes.c_int64,
+    ],
+    None,
+)
+def ggml_cpu_fp16_to_fp32(
+    x: CtypesPointer[ggml_fp16_t],
+    y: CtypesPointer[ctypes.c_float],
+    k: Union[ctypes.c_int64, int],
+    /,
+) -> None:
+    ...
+
+
+# GGML_BACKEND_API void ggml_cpu_fp32_to_bf16(const float * x, ggml_bf16_t * y, int64_t k);
+@ggml_function(
+    "ggml_cpu_fp32_to_bf16",
+    [
+        ctypes.POINTER(ctypes.c_float),
+        ctypes.POINTER(ggml_bf16_t),
+        ctypes.c_int64,
+    ],
+    None,
+)
+def ggml_cpu_fp32_to_bf16(
+    x: CtypesPointer[ctypes.c_float],
+    y: CtypesPointer[ggml_bf16_t],
+    k: Union[ctypes.c_int64, int],
+    /,
+) -> None:
+    ...
+
+
+# GGML_BACKEND_API void ggml_cpu_bf16_to_fp32(const ggml_bf16_t * x, float * y, int64_t k);
+@ggml_function(
+    "ggml_cpu_bf16_to_fp32",
+    [
+        ctypes.POINTER(ggml_bf16_t),
+        ctypes.POINTER(ctypes.c_float),
+        ctypes.c_int64,
+    ],
+    None,
+)
+def ggml_cpu_bf16_to_fp32(
+    x: CtypesPointer[ggml_bf16_t],
+    y: CtypesPointer[ctypes.c_float],
+    k: Union[ctypes.c_int64, int],
+    /,
+) -> None:
+    ...
+
+
 # //
 # // Internal types and functions exposed for tests and benchmarks
 # //

--- a/tests/test_ggml.py
+++ b/tests/test_ggml.py
@@ -84,6 +84,30 @@ def test_ggml_backend_feature_flags_match_exported_symbols():
     assert ggml.GGML_USE_RPC == hasattr(ggml.lib, "ggml_backend_rpc_init")
 
 
+def test_ggml_cpu_conversion_helpers():
+    values = (ctypes.c_float * 3)(1.5, -2.0, 3.25)
+
+    fp32 = (ctypes.c_float * 3)()
+    ggml.ggml_cpu_fp32_to_fp32(values, fp32, 3)
+    assert list(fp32) == [1.5, -2.0, 3.25]
+
+    i32 = (ctypes.c_int32 * 3)()
+    ggml.ggml_cpu_fp32_to_i32(values, i32, 3)
+    assert list(i32) == [1, -2, 3]
+
+    fp16 = (ggml.ggml_fp16_t * 3)()
+    fp16_roundtrip = (ctypes.c_float * 3)()
+    ggml.ggml_cpu_fp32_to_fp16(values, fp16, 3)
+    ggml.ggml_cpu_fp16_to_fp32(fp16, fp16_roundtrip, 3)
+    assert np.allclose(list(fp16_roundtrip), [1.5, -2.0, 3.25], atol=1e-3)
+
+    bf16 = (ggml.ggml_bf16_t * 3)()
+    bf16_roundtrip = (ctypes.c_float * 3)()
+    ggml.ggml_cpu_fp32_to_bf16(values, bf16, 3)
+    ggml.ggml_cpu_bf16_to_fp32(bf16, bf16_roundtrip, 3)
+    assert np.allclose(list(bf16_roundtrip), [1.5, -2.0, 3.25], atol=1e-2)
+
+
 def test_ggml_custom_op():
     params = ggml.ggml_init_params(mem_size=16 * 1024 * 1024, mem_buffer=None)
     ctx = ggml.ggml_init(params)

--- a/tests/test_ggml.py
+++ b/tests/test_ggml.py
@@ -84,30 +84,6 @@ def test_ggml_backend_feature_flags_match_exported_symbols():
     assert ggml.GGML_USE_RPC == hasattr(ggml.lib, "ggml_backend_rpc_init")
 
 
-def test_ggml_cpu_conversion_helpers():
-    values = (ctypes.c_float * 3)(1.5, -2.0, 3.25)
-
-    fp32 = (ctypes.c_float * 3)()
-    ggml.ggml_cpu_fp32_to_fp32(values, fp32, 3)
-    assert list(fp32) == [1.5, -2.0, 3.25]
-
-    i32 = (ctypes.c_int32 * 3)()
-    ggml.ggml_cpu_fp32_to_i32(values, i32, 3)
-    assert list(i32) == [1, -2, 3]
-
-    fp16 = (ggml.ggml_fp16_t * 3)()
-    fp16_roundtrip = (ctypes.c_float * 3)()
-    ggml.ggml_cpu_fp32_to_fp16(values, fp16, 3)
-    ggml.ggml_cpu_fp16_to_fp32(fp16, fp16_roundtrip, 3)
-    assert np.allclose(list(fp16_roundtrip), [1.5, -2.0, 3.25], atol=1e-3)
-
-    bf16 = (ggml.ggml_bf16_t * 3)()
-    bf16_roundtrip = (ctypes.c_float * 3)()
-    ggml.ggml_cpu_fp32_to_bf16(values, bf16, 3)
-    ggml.ggml_cpu_bf16_to_fp32(bf16, bf16_roundtrip, 3)
-    assert np.allclose(list(bf16_roundtrip), [1.5, -2.0, 3.25], atol=1e-2)
-
-
 def test_ggml_custom_op():
     params = ggml.ggml_init_params(mem_size=16 * 1024 * 1024, mem_buffer=None)
     ctx = ggml.ggml_init(params)


### PR DESCRIPTION
Adds CPU conversion helper bindings.

- Adds fp32, i32, fp16, and bf16 CPU conversion wrappers from ggml-cpu.h.
- Adds a runtime roundtrip test for the conversion helpers.