### PR TITLE
fix: handle scalar and boolean numpy tensors

### DIFF
--- a/ggml/utils.py
+++ b/ggml/utils.py
@@ -64,6 +64,10 @@ def to_numpy(
     Returns:
         Numpy array with a view of data from tensor
     """
+    data = ggml.ggml_get_data(tensor)
+    if data is None:
+        return np.array([])
+
     ggml_type = GGML_TYPE(tensor.contents.type)
     if ggml_type == GGML_TYPE.F16:
         ctypes_type = ctypes.c_uint16
@@ -95,6 +99,12 @@ def from_numpy(x: npt.NDArray[Any], ctx: ggml.ggml_context_p) -> ggml.ggml_tenso
     Returns:
         New ggml tensor with data copied from x
     """
+    if x.dtype.type == np.bool_:
+        x = x.astype(np.int32)
+
+    if x.shape == ():
+        x = x.reshape((1,))
+
     ggml_type = NUMPY_DTYPE_TO_GGML_TYPE[x.dtype.type]
     shape = tuple(reversed(x.shape))
     tensor = ggml.ggml_new_tensor(
@@ -107,7 +117,10 @@ def from_numpy(x: npt.NDArray[Any], ctx: ggml.ggml_context_p) -> ggml.ggml_tenso
         *tuple(reversed(x.strides))
     )
     if ggml.ggml_get_data(tensor) is not None:
-        to_numpy(tensor)[:] = x
+        if shape == ():
+            to_numpy(tensor)[()] = x
+        else:
+            to_numpy(tensor)[:] = x
     return tensor
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -33,6 +33,44 @@ def test_numpy_arrays():
     ggml.ggml_free(ctx)
 
 
+def test_from_numpy_bool_array():
+    params = ggml.ggml_init_params(mem_size=16 * 1024 * 1024)
+    ctx = ggml.ggml_init(params)
+    assert ctx is not None
+    x = np.array([True, False, True], dtype=np.bool_)
+    t = ggml.utils.from_numpy(x, ctx)
+    assert t.contents.type == ggml.GGML_TYPE_I32
+    assert np.array_equal(ggml.utils.to_numpy(t), x.astype(np.int32))
+    ggml.ggml_free(ctx)
+
+
+def test_from_numpy_scalar_array():
+    params = ggml.ggml_init_params(mem_size=16 * 1024 * 1024)
+    ctx = ggml.ggml_init(params)
+    assert ctx is not None
+    x = np.array(3.5, dtype=np.float32)
+    t = ggml.utils.from_numpy(x, ctx)
+    y = ggml.utils.to_numpy(t)
+    assert y.shape == (1,)
+    assert np.array_equal(y, np.array([3.5], dtype=np.float32))
+    ggml.ggml_free(ctx)
+
+
+def test_to_numpy_no_alloc_tensor():
+    params = ggml.ggml_init_params(
+        mem_size=16 * 1024 * 1024,
+        mem_buffer=None,
+        no_alloc=True,
+    )
+    ctx = ggml.ggml_init(params)
+    assert ctx is not None
+    t = ggml.ggml_new_tensor_1d(ctx, ggml.GGML_TYPE_F32, 3)
+    assert ggml.ggml_get_data(t) is None
+    y = ggml.utils.to_numpy(t)
+    assert y.shape == (0,)
+    ggml.ggml_free(ctx)
+
+
 def test_numpy_arrays_transposed():
     params = ggml.ggml_init_params(mem_size=16 * 1024 * 1024)
     ctx = ggml.ggml_init(params)


### PR DESCRIPTION
Handle numpy tensor conversion edge cases needed by higher-level runtimes.

- Convert boolean numpy arrays to int32 ggml storage.
- Treat scalar numpy arrays as one-element ggml tensors.
- Return an empty array for no-allocation tensors without data.
- Add focused utility tests.
