### PR TITLE
docs: add native crash debugging notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,21 @@ If you are having trouble installing `ggml-python` or activating specific featur
 pip install ggml-python --verbose --no-cache-dir --force-reinstall --upgrade
 ```
 
+## Native Crashes
+
+If you are debugging a `SIGSEGV`, `SIGABRT`, or `Aborted (core dumped)` failure, reproduce it with a debug build so native symbols are available.
+
+```bash
+git clone https://github.com/abetlen/ggml-python.git
+cd ggml-python
+make build.debug
+gdb --args python3 your_script.py
+```
+
+Inside `gdb`, use `run` to start the script, `bt` to inspect the native backtrace, and `py-bt` to inspect the Python backtrace when Python debug symbols are available.
+
+You can also use Python's built-in `breakpoint()` to stop before the native call that crashes.
+
 # License
 
 This project is licensed under the terms of the MIT license.


### PR DESCRIPTION
Document basic native crash debugging workflow for ggml-python.

- Add debug build and gdb commands for SIGSEGV and SIGABRT failures.
- Keep the README change separate from the ONNX backend PR.
