### PR TITLE
fix(ci): rebuild wheel index after release asset workflows

### DIFF
--- a/.github/workflows/wheels-index.yaml
+++ b/.github/workflows/wheels-index.yaml
@@ -1,9 +1,11 @@
 name: Wheels Index
 
 on:
-  # Trigger on any new release
-  release:
-    types: [published]
+  # Trigger when release-asset workflows complete.
+  workflow_run:
+    workflows: ["Publish", "Wheels", "Wheels CUDA", "Wheels Metal", "Wheels Vulkan", "Wheels ROCm"]
+    types:
+      - completed
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -33,7 +35,10 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          ./scripts/get-releases.sh
           ./scripts/releases-to-pep-503.sh index/whl/cpu '^[v]?[0-9]+\.[0-9]+\.[0-9]+$'
           ./scripts/releases-to-pep-503.sh index/whl/cu118 '^[v]?[0-9]+\.[0-9]+\.[0-9]+-cu118$'
           ./scripts/releases-to-pep-503.sh index/whl/cu121 '^[v]?[0-9]+\.[0-9]+\.[0-9]+-cu121$'
@@ -51,7 +56,7 @@ jobs:
         uses: actions/upload-pages-artifact@v3
         with:
           # Upload entire repository
-          path: "index"
+          path: 'index'
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- fix(ci): rebuild wheel index after release asset workflows by @abetlen in #133
 - feat(contrib): add ONNX backend by @dmille, @mrezanvari, and @abetlen in #23
 - feat: add missing ggml.h bindings by @abetlen in #118
 - feat: add CUDA backend bindings by @abetlen in #119

--- a/scripts/get-releases.sh
+++ b/scripts/get-releases.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Function to get all releases
+get_all_releases() {
+    local page=1
+    local per_page=100
+    local releases=""
+    local new_releases
+
+    # Prepare headers
+    local headers=(-H "Accept: application/vnd.github.v3+json")
+    if [ -n "$GITHUB_TOKEN" ]; then
+        headers+=(-H "Authorization: Bearer $GITHUB_TOKEN")
+    fi
+
+    while true; do
+        response=$(curl -s "${headers[@]}" \
+                        "https://api.github.com/repos/abetlen/ggml-python/releases?page=$page&per_page=$per_page")
+
+        # Check if the response is valid JSON
+        if ! echo "$response" | jq empty > /dev/null 2>&1; then
+            echo "Error: Invalid response from GitHub API" >&2
+            echo "Response: $response" >&2
+            return 1
+        fi
+
+        new_releases=$(echo "$response" | jq -r '.[].tag_name')
+        if [ -z "$new_releases" ]; then
+            break
+        fi
+        releases="$releases $new_releases"
+        ((page++))
+    done
+
+    echo $releases
+}
+
+# Get all releases and save to file
+releases=$(get_all_releases)
+if [ $? -ne 0 ]; then
+    echo "Failed to fetch releases. Please check your internet connection and try again later." >&2
+    exit 1
+fi
+
+echo "$releases" | tr ' ' '\n' > all_releases.txt
+
+echo "All releases have been saved to all_releases.txt"

--- a/scripts/releases-to-pep-503.sh
+++ b/scripts/releases-to-pep-503.sh
@@ -1,58 +1,108 @@
 #!/bin/bash
 
+# Enable exit on error
+set -e
+
+# Function for logging
+log_error() {
+    echo "ERROR: $1" >&2
+}
+
+log_info() {
+    echo "INFO: $1"
+}
+
 # Get output directory or default to index/whl/cpu
 output_dir=${1:-"index/whl/cpu"}
-
-# Create output directory
-mkdir -p $output_dir
-
-# Change to output directory
-pushd $output_dir
-
-# Create an index html file
-echo "<!DOCTYPE html>" > index.html
-echo "<html>" >> index.html
-echo "  <head></head>" >> index.html
-echo "  <body>" >> index.html
-echo "    <a href=\"ggml-python/\">ggml-python</a>" >> index.html
-echo "    <br>" >> index.html
-echo "  </body>" >> index.html
-echo "</html>" >> index.html
-echo "" >> index.html
-
-# Create ggml-python directory
-mkdir -p ggml-python
-
-# Change to ggml-python directory
-pushd ggml-python
-
-# Create an index html file
-echo "<!DOCTYPE html>" > index.html
-echo "<html>" >> index.html
-echo "  <body>" >> index.html
-echo "    <h1>Links for ggml-python</h1>" >> index.html
-
-# Get all releases
-releases=$(curl -s https://api.github.com/repos/abetlen/ggml-python/releases | jq -r .[].tag_name)
 
 # Get pattern from second arg or default to valid python package version pattern
 pattern=${2:-"^[v]?[0-9]+\.[0-9]+\.[0-9]+$"}
 
-# Filter releases by pattern
-releases=$(echo $releases | tr ' ' '\n' | grep -E $pattern)
+# Get the current directory (where the script is run from)
+current_dir="$(pwd)"
+
+# Check if all_releases.txt exists
+if [ ! -f "$current_dir/all_releases.txt" ]; then
+    log_error "all_releases.txt not found in the current directory."
+    exit 1
+fi
+
+# Create output directory
+mkdir -p "$output_dir"
+
+# Create an index html file
+cat << EOF > "$output_dir/index.html"
+<!DOCTYPE html>
+<html>
+  <head></head>
+  <body>
+    <a href="ggml-python/">ggml-python</a>
+    <br>
+  </body>
+</html>
+
+EOF
+
+# Create ggml-python directory
+mkdir -p "$output_dir/ggml-python"
+
+# Create an index html file
+cat << EOF > "$output_dir/ggml-python/index.html"
+<!DOCTYPE html>
+<html>
+  <body>
+    <h1>Links for ggml-python</h1>
+EOF
+
+# Filter releases by pattern. Some backend indexes are valid even when there
+# are no matching releases yet.
+releases=$(grep -E "$pattern" "$current_dir/all_releases.txt" || true)
+if [ -z "$releases" ]; then
+    log_info "No releases found matching pattern: $pattern"
+fi
+
+# Prepare curl headers
+headers=('--header' 'Accept: application/vnd.github.v3+json')
+if [ -n "$GITHUB_TOKEN" ]; then
+    headers+=('--header' "authorization: Bearer $GITHUB_TOKEN")
+fi
+headers+=('--header' 'content-type: application/json')
 
 # For each release, get all assets
 for release in $releases; do
-    assets=$(curl -s https://api.github.com/repos/abetlen/ggml-python/releases/tags/$release | jq -r .assets)
-    echo "    <h2>$release</h2>" >> index.html
-    for asset in $(echo $assets | jq -r .[].browser_download_url); do
-        if [[ $asset == *".whl" ]]; then
-            echo "    <a href=\"$asset\">$asset</a>" >> index.html
-            echo "    <br>" >> index.html
-        fi
+    log_info "Processing release: $release"
+    response=$(curl -s "${headers[@]}" \
+                    "https://api.github.com/repos/abetlen/ggml-python/releases/tags/$release")
+
+    if [ -z "$response" ]; then
+        log_error "Empty response from GitHub API for release $release"
+        continue
+    fi
+
+    if ! echo "$response" | jq -e '.assets' > /dev/null 2>&1; then
+        log_error "Invalid or unexpected response from GitHub API for release $release"
+        log_error "Response: $response"
+        continue
+    fi
+
+    wheel_urls=$(echo "$response" | jq -r '.assets[] | select(.name | endswith(".whl")) | .browser_download_url')
+    if [ -z "$wheel_urls" ]; then
+        log_error "No wheel files found for release $release"
+        continue
+    fi
+
+    # Get release version from release ie v0.1.0-cu121 -> v0.1.0
+    release_version=$(echo "$release" | grep -oE "^[v]?[0-9]+\.[0-9]+\.[0-9]+")
+    echo "    <h2>$release_version</h2>" >> "$output_dir/ggml-python/index.html"
+
+    echo "$wheel_urls" | while read -r asset; do
+        echo "    <a href=\"$asset\">$asset</a>" >> "$output_dir/ggml-python/index.html"
+        echo "    <br>" >> "$output_dir/ggml-python/index.html"
     done
 done
 
-echo "  </body>" >> index.html
-echo "</html>" >> index.html
-echo "" >> index.html
+echo "  </body>" >> "$output_dir/ggml-python/index.html"
+echo "</html>" >> "$output_dir/ggml-python/index.html"
+echo "" >> "$output_dir/ggml-python/index.html"
+
+log_info "Index generation complete. Output directory: $output_dir"


### PR DESCRIPTION
Fix wheel index generation so it runs after release asset workflows complete.

- Trigger Pages index generation from release workflow completion.
- Fetch all GitHub releases before generating backend indexes.
- Allow empty backend indexes without failing the Pages build.