### PR TITLE
release: bump version to 0.0.40

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.40]
+
 - fix(ci): rebuild wheel index after release asset workflows by @abetlen in #133
 - ci: update GitHub Actions workflow dependencies by @abetlen in #134
 - fix(ci): repair release wheel builds for cibuildwheel v3 by @abetlen in #135

--- a/ggml/__init__.py
+++ b/ggml/__init__.py
@@ -1,3 +1,3 @@
 from .ggml import *
 
-__version__ = "0.0.39"
+__version__ = "0.0.40"


### PR DESCRIPTION
Prepare the 0.0.40 release.

- Bump package version to 0.0.40.
- Move unreleased changelog entries under 0.0.40.