### PR TITLE
fix(ci): build portable Linux Vulkan wheels

### DIFF
--- a/.github/workflows/wheels-vulkan.yaml
+++ b/.github/workflows/wheels-vulkan.yaml
@@ -46,23 +46,6 @@ jobs:
           cache: "pip"
 
       - name: Install Vulkan SDK
-        if: runner.os == 'Linux'
-        run: |
-          curl -fL \
-            "https://sdk.lunarg.com/sdk/download/${VULKAN_SDK_VERSION}/linux/vulkansdk-linux-x86_64-${VULKAN_SDK_VERSION}.tar.xz" \
-            -o vulkan-sdk.tar.xz
-          echo "${VULKAN_SDK_LINUX_SHA256}  vulkan-sdk.tar.xz" | sha256sum -c -
-          mkdir -p "$RUNNER_TEMP/vulkan-sdk"
-          tar -xf vulkan-sdk.tar.xz -C "$RUNNER_TEMP/vulkan-sdk"
-          source "$RUNNER_TEMP/vulkan-sdk/${VULKAN_SDK_VERSION}/setup-env.sh"
-          {
-            echo "VULKAN_SDK=$VULKAN_SDK"
-            echo "LD_LIBRARY_PATH=$VULKAN_SDK/lib:${LD_LIBRARY_PATH:-}"
-          } >> "$GITHUB_ENV"
-          echo "$VULKAN_SDK/bin" >> "$GITHUB_PATH"
-          "$VULKAN_SDK/bin/glslc" --version
-
-      - name: Install Vulkan SDK
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
@@ -76,6 +59,7 @@ jobs:
           & "$vulkanSdk\Bin\glslc.exe" --version
 
       - name: Install build dependencies
+        if: runner.os == 'Windows'
         run: |
           python -m pip install --upgrade pip
           python -m pip install build wheel
@@ -86,11 +70,29 @@ jobs:
 
       - name: Build Vulkan wheel
         if: runner.os == 'Linux'
-        run: |
-          export CMAKE_ARGS="-DGGML_NATIVE=off -DGGML_METAL=OFF -DGGML_VULKAN=on"
-          python -m build --wheel
-          mkdir -p wheelhouse
-          cp dist/*.whl wheelhouse/
+        uses: pypa/cibuildwheel@v3.4.1
+        env:
+          CIBW_BUILD: "cp38-manylinux_*"
+          CIBW_ARCHS: "auto64"
+          CIBW_MANYLINUX_X86_64_IMAGE: "manylinux2014"
+          CIBW_BEFORE_ALL_LINUX: >
+            yum install -y xz &&
+            curl -L https://micro.mamba.pm/api/micromamba/linux-64/latest -o /tmp/micromamba.tar.bz2 &&
+            mkdir -p /tmp/micromamba &&
+            tar -xjf /tmp/micromamba.tar.bz2 -C /tmp/micromamba bin/micromamba &&
+            /tmp/micromamba/bin/micromamba create -y -p /opt/shaderc -c conda-forge shaderc &&
+            /opt/shaderc/bin/glslc --version &&
+            curl -fL "https://sdk.lunarg.com/sdk/download/${{ env.VULKAN_SDK_VERSION }}/linux/vulkansdk-linux-x86_64-${{ env.VULKAN_SDK_VERSION }}.tar.xz" -o /tmp/vulkan-sdk.tar.xz &&
+            echo "${{ env.VULKAN_SDK_LINUX_SHA256 }}  /tmp/vulkan-sdk.tar.xz" | sha256sum -c - &&
+            mkdir -p /opt/vulkan-sdk &&
+            tar -xf /tmp/vulkan-sdk.tar.xz -C /opt/vulkan-sdk
+          CIBW_ENVIRONMENT_LINUX: >
+            VULKAN_SDK=/opt/vulkan-sdk/${{ env.VULKAN_SDK_VERSION }}/x86_64
+            CMAKE_ARGS="-DGGML_NATIVE=off -DGGML_METAL=OFF -DGGML_OPENMP=OFF -DGGML_VULKAN=on -DVulkan_GLSLC_EXECUTABLE=/opt/shaderc/bin/glslc"
+          CIBW_REPAIR_WHEEL_COMMAND_LINUX: "LD_LIBRARY_PATH=/project/ggml/lib:/opt/vulkan-sdk/${{ env.VULKAN_SDK_VERSION }}/x86_64/lib auditwheel repair --exclude libvulkan.so.1 -w {dest_dir} {wheel}"
+        with:
+          package-dir: .
+          output-dir: wheelhouse
 
       - name: Build Vulkan wheel
         if: runner.os == 'Windows'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- fix(ci): build Linux Vulkan wheels on a manylinux baseline by @abetlen in #137
+
 ## [0.0.40]
 
 - fix(ci): rebuild wheel index after release asset workflows by @abetlen in #133


### PR DESCRIPTION
Build Linux Vulkan wheels on a portable manylinux baseline.

- Use cibuildwheel and auditwheel repair for Linux Vulkan wheels.
- Compile Vulkan shaders with a build-only shaderc tool inside manylinux.
- Keep libvulkan external and disable OpenMP to avoid newer libstdc++/libgomp runtime requirements.
- Validated a repaired wheel in a native temp venv with Vulkan graph computation.