### PR TITLE
fix(ci): repair Linux CUDA wheel tags

### DIFF
--- a/.github/workflows/wheels-cuda.yaml
+++ b/.github/workflows/wheels-cuda.yaml
@@ -136,7 +136,9 @@ jobs:
           if ($IsWindows) {
             python -m pip install build wheel ninja
           } else {
-            python -m pip install build wheel
+            sudo apt-get update
+            sudo apt-get install -y patchelf
+            python -m pip install build wheel auditwheel
           }
 
       - name: Build Wheel
@@ -174,6 +176,12 @@ jobs:
             $env:CPLUS_INCLUDE_PATH = "$cudaRoot/include$pathSeparator$env:CPLUS_INCLUDE_PATH"
             $env:LIBRARY_PATH = "$cudaRoot/lib$pathSeparator$env:CONDA_PREFIX/lib$pathSeparator$env:LIBRARY_PATH"
             $env:LD_LIBRARY_PATH = "$cudaRoot/lib$pathSeparator$env:CONDA_PREFIX/lib$pathSeparator$env:LD_LIBRARY_PATH"
+            $cudaLibraryPaths = @(
+              (Join-Path $cudaRoot 'lib'),
+              (Join-Path $cudaRoot 'lib64'),
+              (Join-Path $env:CONDA_PREFIX 'lib')
+            ) | Where-Object { Test-Path $_ }
+            Write-Output "CUDA_LIBRARY_PATHS=$($cudaLibraryPaths -join ':')" >> $env:GITHUB_ENV
           } elseif ($IsWindows) {
             $ninjaPath = ((Get-Command ninja -ErrorAction Stop).Source).Replace('\', '/')
             $env:CMAKE_GENERATOR = 'Ninja'
@@ -225,9 +233,37 @@ jobs:
           if ($env:AVXVER -eq 'basic') {
             $env:CMAKE_ARGS = $env:CMAKE_ARGS + ' -DGGML_AVX=off'
           }
+          if ($IsLinux) {
+            $env:CMAKE_ARGS = $env:CMAKE_ARGS + ' -DGGML_OPENMP=OFF'
+          }
           python -m build --wheel
           # Publish tags that reflect the actual installed toolkit version.
           Write-Output "CUDA_VERSION=$cudaTagVersion" >> $env:GITHUB_ENV
+
+      - name: Repair Linux wheel
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -euxo pipefail
+          mkdir -p wheelhouse
+          export LD_LIBRARY_PATH="${CUDA_LIBRARY_PATHS}:${LD_LIBRARY_PATH:-}"
+          auditwheel repair \
+            --exclude libcuda.so \
+            --exclude libcuda.so.1 \
+            --exclude libcudart.so.11.0 \
+            --exclude libcudart.so.12 \
+            --exclude libcudart.so.13 \
+            --exclude libcublas.so.11 \
+            --exclude libcublas.so.12 \
+            --exclude libcublas.so.13 \
+            --exclude libcublasLt.so.11 \
+            --exclude libcublasLt.so.12 \
+            --exclude libcublasLt.so.13 \
+            -w wheelhouse \
+            dist/*.whl
+          rm dist/*.whl
+          cp wheelhouse/*.whl dist/
+          auditwheel show dist/*.whl
 
       - uses: softprops/action-gh-release@v3
         if: startsWith(github.ref, 'refs/tags/')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- fix(ci): repair Linux CUDA wheel tags by @abetlen in #138
 - fix(ci): build Linux Vulkan wheels on a manylinux baseline by @abetlen in #137
 
 ## [0.0.40]


### PR DESCRIPTION
Repair Linux CUDA wheels before release upload.

- Install auditwheel and patchelf for Linux CUDA builds.
- Repair Linux CUDA wheels into audited platform tags.
- Keep CUDA driver and CUDA runtime libraries external.
- Disable OpenMP for Linux CUDA wheels to avoid host libgomp dependencies.