### PR TITLE
fix(ci): repair Linux ROCm wheel tags

### DIFF
--- a/.github/workflows/wheels-rocm.yaml
+++ b/.github/workflows/wheels-rocm.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Install system dependencies
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends git cmake lsb-release ninja-build
+          apt-get install -y --no-install-recommends git cmake lsb-release ninja-build patchelf
 
       - uses: actions/checkout@v6
         with:
@@ -50,7 +50,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install build wheel
+          python -m pip install auditwheel build wheel
 
       - name: Build wheel
         env:
@@ -73,8 +73,37 @@ jobs:
           echo "ROCM_VERSION=$rocm_tag" >> "$GITHUB_ENV"
 
           amdgpu_targets="${INPUT_AMDGPU_TARGETS:-$MATRIX_AMDGPU_TARGETS}"
-          export CMAKE_ARGS="-DGGML_HIP=on -DGGML_NATIVE=off -DGGML_AVX=off -DGGML_AVX2=off -DGGML_FMA=off -DGGML_F16C=off -DAMDGPU_TARGETS=$amdgpu_targets -DCMAKE_HIP_ARCHITECTURES=$amdgpu_targets"
+          export CMAKE_ARGS="-DGGML_HIP=on -DGGML_NATIVE=off -DGGML_OPENMP=OFF -DGGML_AVX=off -DGGML_AVX2=off -DGGML_FMA=off -DGGML_F16C=off -DAMDGPU_TARGETS=$amdgpu_targets -DCMAKE_HIP_ARCHITECTURES=$amdgpu_targets"
           python -m build --wheel
+
+      - name: Repair Linux wheel
+        run: |
+          export ROCM_PATH="${ROCM_PATH:-/opt/rocm}"
+          export LD_LIBRARY_PATH="$ROCM_PATH/lib:$ROCM_PATH/lib64:${LD_LIBRARY_PATH:-}"
+          mkdir -p wheelhouse
+          auditwheel repair \
+            --exclude libamdhip64.so \
+            --exclude libamdhip64.so.6 \
+            --exclude libamdhip64.so.7 \
+            --exclude libhiprtc.so \
+            --exclude libhiprtc.so.6 \
+            --exclude libhiprtc.so.7 \
+            --exclude libhipblas.so \
+            --exclude libhipblas.so.2 \
+            --exclude libhipblas.so.3 \
+            --exclude libhipblaslt.so \
+            --exclude libhipblaslt.so.0 \
+            --exclude libhipblaslt.so.1 \
+            --exclude librocblas.so \
+            --exclude librocblas.so.4 \
+            --exclude librocblas.so.5 \
+            --exclude libhsa-runtime64.so.1 \
+            --exclude libhsakmt.so.1 \
+            -w wheelhouse \
+            dist/*.whl
+          rm dist/*.whl
+          cp wheelhouse/*.whl dist/
+          auditwheel show dist/*.whl
 
       - uses: actions/upload-artifact@v7
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - fix(ci): repair Linux CUDA wheel tags by @abetlen in #138
+- fix(ci): repair Linux ROCm wheel tags by @abetlen in #139
 - fix(ci): build Linux Vulkan wheels on a manylinux baseline by @abetlen in #137
 
 ## [0.0.40]


### PR DESCRIPTION
Repair Linux ROCm wheels before release upload.

- Install auditwheel and patchelf for Linux ROCm builds.
- Repair Linux ROCm wheels into audited platform tags.
- Keep ROCm driver and runtime libraries external.
- Disable OpenMP for Linux ROCm wheels to avoid host libgomp dependencies.
