### PR TITLE
fix(build): default GGML_METAL to OFF to match docs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -113,7 +113,7 @@ jobs:
           python3 -m pip install --upgrade pip pytest cmake scikit-build setuptools
           python3 -m pip install \
             --verbose \
-            --config-settings cmake.args='-DCMAKE_BUILD_TYPE=Debug;-DCMAKE_CXX_FLAGS=-g3;-DCMAKE_C_FLAGS=-g3;-DGGML_NATIVE=off' \
+            --config-settings cmake.args='-DCMAKE_BUILD_TYPE=Debug;-DCMAKE_CXX_FLAGS=-g3;-DCMAKE_C_FLAGS=-g3;-DGGML_NATIVE=off;-DGGML_METAL=OFF' \
             --config-settings cmake.verbose=true \
             --config-settings logging.level=INFO \
             --config-settings install.strip=false \
@@ -143,7 +143,7 @@ jobs:
           python3 -m pip install --upgrade pip pytest cmake scikit-build setuptools
           python3 -m pip install \
             --verbose \
-            --config-settings cmake.args='-DCMAKE_BUILD_TYPE=Debug;-DCMAKE_CXX_FLAGS=-g3;-DCMAKE_C_FLAGS=-g3;-DGGML_NATIVE=off' \
+            --config-settings cmake.args='-DCMAKE_BUILD_TYPE=Debug;-DCMAKE_CXX_FLAGS=-g3;-DCMAKE_C_FLAGS=-g3;-DGGML_NATIVE=off;-DGGML_METAL=OFF' \
             --config-settings cmake.verbose=true \
             --config-settings logging.level=INFO \
             --config-settings install.strip=false \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- fix(build): make Metal backend builds opt in by @abetlen in #140
+- fix(build): default GGML_METAL to OFF to match docs by @abetlen in #140
 - fix(ci): repair Linux CUDA wheel tags by @abetlen in #138
 - fix(ci): repair Linux ROCm wheel tags by @abetlen in #139
 - fix(ci): build Linux Vulkan wheels on a manylinux baseline by @abetlen in #137

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- fix(build): make Metal backend builds opt in by @abetlen in #140
 - fix(ci): repair Linux CUDA wheel tags by @abetlen in #138
 - fix(ci): repair Linux ROCm wheel tags by @abetlen in #139
 - fix(ci): build Linux Vulkan wheels on a manylinux baseline by @abetlen in #137

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,13 @@ if (APPLE)
         set(GGML_F16C "Off" CACHE BOOL "ggml: enable F16C" FORCE)
     endif()
 
-    set(GGML_METAL_EMBED_LIBRARY "On" CACHE BOOL "ggml: embed metal library" FORCE)
+    if (NOT DEFINED GGML_METAL)
+        set(GGML_METAL "Off" CACHE BOOL "ggml: enable Metal" FORCE)
+    endif()
+
+    if (GGML_METAL)
+        set(GGML_METAL_EMBED_LIBRARY "On" CACHE BOOL "ggml: embed metal library" FORCE)
+    endif()
 endif()
 add_subdirectory(vendor/ggml)
 


### PR DESCRIPTION
Default GGML_METAL to OFF on macOS source builds to match the documented backend default.

- Set GGML_METAL=Off before vendored ggml configures unless the user opts in.
- Only force embedded Metal shaders when Metal is enabled.
- Disable Metal explicitly in normal macOS test jobs while keeping the Metal job opt-in.

Closes #111.