### PR TITLE
fix(build): reduce duplicate Linux wheel libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- fix(build): reduce duplicate Linux wheel library files by @abetlen in #141
 - fix(build): default GGML_METAL to OFF to match docs by @abetlen in #140
 - fix(ci): repair Linux CUDA wheel tags by @abetlen in #138
 - fix(ci): repair Linux ROCm wheel tags by @abetlen in #139

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,14 @@ set(GGML_PYTHON_TARGETS
 
 foreach(GGML_PYTHON_TARGET IN LISTS GGML_PYTHON_TARGETS)
     if(TARGET ${GGML_PYTHON_TARGET})
+        if(UNIX AND NOT APPLE)
+            set_target_properties(${GGML_PYTHON_TARGET} PROPERTIES
+                NO_SONAME TRUE
+                RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
+                LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
+            )
+        endif()
+
         install(
             TARGETS ${GGML_PYTHON_TARGET}
             ARCHIVE DESTINATION ${GGML_PYTHON_INSTALL_DIR}


### PR DESCRIPTION
Reduce duplicate Linux shared library files in built wheels.

- Disable SONAME generation for packaged ggml targets on non-Apple Unix builds.
- Keep packaged shared libraries in the build root so local NEEDED entries resolve without bin/ prefixes.
- Verified a local CPU wheel shrank from 4.3M with 18 shared-object entries to 1.6M with 6 entries.
- Verified the built wheel imports and runs a simple ggml graph.
