### PR TITLE
release: bump version to 0.0.41

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.41]
+
 - fix(build): reduce duplicate Linux wheel library files by @abetlen in #141
 - fix(build): default GGML_METAL to OFF to match docs by @abetlen in #140
 - fix(ci): repair Linux CUDA wheel tags by @abetlen in #138

--- a/ggml/__init__.py
+++ b/ggml/__init__.py
@@ -1,3 +1,3 @@
 from .ggml import *
 
-__version__ = "0.0.40"
+__version__ = "0.0.41"


### PR DESCRIPTION
Prepare the 0.0.41 release.

- Bump package version to 0.0.41.
- Move unreleased changelog entries under 0.0.41.
