### PR TITLE
fix(ci): install auditwheel in accelerator repair steps

### DIFF
--- a/.github/workflows/wheels-cuda.yaml
+++ b/.github/workflows/wheels-cuda.yaml
@@ -252,6 +252,7 @@ jobs:
           set -euxo pipefail
           mkdir -p wheelhouse
           export LD_LIBRARY_PATH="${CUDA_LIBRARY_PATHS}:${LD_LIBRARY_PATH:-}"
+          python -m pip install auditwheel
           python -m auditwheel repair \
             --exclude libcuda.so \
             --exclude libcuda.so.1 \

--- a/.github/workflows/wheels-rocm.yaml
+++ b/.github/workflows/wheels-rocm.yaml
@@ -85,6 +85,7 @@ jobs:
           export ROCM_PATH="${ROCM_PATH:-/opt/rocm}"
           export LD_LIBRARY_PATH="$ROCM_PATH/lib:$ROCM_PATH/lib64:${LD_LIBRARY_PATH:-}"
           mkdir -p wheelhouse
+          python -m pip install auditwheel
           python -m auditwheel repair \
             --exclude libamdhip64.so \
             --exclude libamdhip64.so.6 \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- fix(ci): install auditwheel in accelerator repair steps
 - fix(ci): repair accelerator wheel workflow dispatch publishing
 
 ## [0.0.41]


### PR DESCRIPTION
Install auditwheel in the repair step interpreter.

- Install auditwheel inside Linux accelerator repair steps before python -m auditwheel.
- Keeps CUDA and ROCm repair steps independent of the earlier conda/Python environment.
