### PR TITLE
feat: add graph allocator reserve size binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- feat: add graph allocator reserve size binding by @abetlen in #159
 - feat(gguf): add buffer and file pointer APIs by @aisk in #158
 - fix: sync updated GGUF API signatures by @aisk in #155
 - feat: update vendored ggml to 0.15.1 by @abetlen in #157

--- a/ggml/ggml.py
+++ b/ggml/ggml.py
@@ -12386,6 +12386,35 @@ def ggml_gallocr_reserve(
     ...
 
 
+# GGML_API void ggml_gallocr_reserve_n_size(
+#     ggml_gallocr_t galloc,
+#     struct ggml_cgraph * graph,
+#     const int * node_buffer_ids,
+#     const int * leaf_buffer_ids,
+#     size_t * sizes);
+@ggml_function(
+    "ggml_gallocr_reserve_n_size",
+    [
+        ggml_gallocr_ctypes,
+        ctypes.POINTER(ggml_cgraph),
+        ctypes.POINTER(ctypes.c_int),
+        ctypes.POINTER(ctypes.c_int),
+        ctypes.POINTER(ctypes.c_size_t),
+    ],
+    None,
+)
+def ggml_gallocr_reserve_n_size(
+    galloc: Union[ggml_gallocr, int],
+    graph: ggml_cgraph_p,
+    node_buffer_ids: CtypesPointer[ctypes.c_int],
+    leaf_buffer_ids: CtypesPointer[ctypes.c_int],
+    sizes: CtypesPointer[ctypes.c_size_t],
+    /,
+) -> None:
+    """write the buffer sizes that would be allocated by ggml_gallocr_reserve_n"""
+    ...
+
+
 # GGML_API bool ggml_gallocr_reserve_n(
 #     ggml_gallocr_t galloc,
 #     struct ggml_cgraph * graph,


### PR DESCRIPTION
Add the missing graph allocator reserve-size binding.

- Bind ggml_gallocr_reserve_n_size beside the existing graph allocator reserve APIs.
