### PR TITLE
feat: add VirtGPU backend registry binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- feat: add VirtGPU backend registry binding by @abetlen in #161
 - feat(gguf): add callback reader initialization binding by @abetlen in #160
 - feat: add graph allocator reserve size binding by @abetlen in #159
 - feat(gguf): add buffer and file pointer APIs by @aisk in #158

--- a/ggml/ggml.py
+++ b/ggml/ggml.py
@@ -14927,6 +14927,26 @@ def ggml_backend_webgpu_reg() -> Optional[ggml_backend_reg_t]:
 
 
 #####################################################
+# GGML VirtGPU API
+# source: include/ggml-virtgpu.h
+#####################################################
+
+
+GGML_USE_VIRTGPU = hasattr(lib, "ggml_backend_virtgpu_reg")
+
+
+# GGML_BACKEND_API ggml_backend_reg_t ggml_backend_virtgpu_reg();
+@ggml_function(
+    "ggml_backend_virtgpu_reg",
+    [],
+    ggml_backend_reg_t_ctypes,
+    enabled=GGML_USE_VIRTGPU,
+)
+def ggml_backend_virtgpu_reg() -> Optional[ggml_backend_reg_t]:
+    ...
+
+
+#####################################################
 # GGML ZenDNN API
 # source: src/ggml-zendnn.h
 #####################################################


### PR DESCRIPTION
Add the missing VirtGPU backend registry binding.

- Bind ggml_backend_virtgpu_reg behind the optional VirtGPU symbol gate.
