### PR TITLE
release: bump version to 0.0.42

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.42]
+
 - feat: sync ggml optimizer bindings by @abetlen in #163
 - feat: add missing backend runtime bindings by @abetlen in #162
 - feat: add VirtGPU backend registry binding by @abetlen in #161

--- a/ggml/__init__.py
+++ b/ggml/__init__.py
@@ -1,3 +1,3 @@
 from .ggml import *
 
-__version__ = "0.0.41"
+__version__ = "0.0.42"


### PR DESCRIPTION
Prepare the 0.0.42 release.

- Bump the package version to 0.0.42.
- Move unreleased changelog entries under 0.0.42.