### PR TITLE
fix: correct ggml_blck_size return type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- fix: correct ggml_blck_size return type by @aisk in #166
+
 ## [0.0.42]
 
 - feat: sync ggml optimizer bindings by @abetlen in #163

--- a/ggml/ggml.py
+++ b/ggml/ggml.py
@@ -1576,8 +1576,8 @@ def ggml_nbytes_pad(tensor: ggml_tensor_p, /) -> int:
     ...
 
 
-# GGML_API GGML_CALL int    ggml_blck_size(enum ggml_type type);
-@ggml_function("ggml_blck_size", [ctypes.c_int], ctypes.c_int)
+# GGML_API GGML_CALL int64_t ggml_blck_size(enum ggml_type type);
+@ggml_function("ggml_blck_size", [ctypes.c_int], ctypes.c_int64)
 def ggml_blck_size(type: Union[ctypes.c_int, int], /) -> int:
     ...
 


### PR DESCRIPTION
Fixes the Python ctypes binding for `ggml_blck_size` to use `c_int64`, matching the current vendored ggml `int64_t` return type:

https://github.com/ggml-org/ggml/blob/f158c1924db896324d47aa7ef6314a86540584b5/include/ggml.h#L741