### PR TITLE
release: bump version to 0.0.43

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.43]
+
 - feat: update vendored ggml to 0.15.2 by @abetlen in #167
 - fix: correct ggml_blck_size return type by @aisk in #166
 

--- a/ggml/__init__.py
+++ b/ggml/__init__.py
@@ -1,3 +1,3 @@
 from .ggml import *
 
-__version__ = "0.0.42"
+__version__ = "0.0.43"


### PR DESCRIPTION
Prepare the 0.0.43 release.

- Bump the package version to 0.0.43.
- Move unreleased changelog entries under 0.0.43.