### PR TITLE
fix: bind ggml abort and backend guid API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- fix: sync ggml binding signatures by @aisk in #170
+- fix: bind ggml abort and backend guid API by @aisk in #169
+- fix: sync updated gguf and backend binding signatures by @aisk in #170
 
 ## [0.0.43]
 

--- a/ggml/ggml.py
+++ b/ggml/ggml.py
@@ -333,6 +333,21 @@ def ggml_set_abort_callback(callback: ggml_abort_callback_t, /) -> ggml_abort_ca
     ...
 
 
+# GGML_API void ggml_abort(const char * file, int line, const char * fmt, ...);
+@ggml_function(
+    "ggml_abort",
+    [ctypes.c_char_p, ctypes.c_int, ctypes.c_char_p],
+    None,
+)
+def ggml_abort(
+    file: bytes,
+    line: Union[ctypes.c_int, int],
+    fmt: bytes,
+    *args: Any,
+) -> None:
+    ...
+
+
 # // ieee 754-2008 half-precision float16
 # // todo: make this not an integral type
 # typedef uint16_t ggml_fp16_t;
@@ -13061,7 +13076,14 @@ def ggml_backend_buffer_reset(buffer: Union[ggml_backend_buffer_t, int], /):
 
 
 # GGML_API ggml_guid_t  ggml_backend_guid(ggml_backend_t backend);
-def ggml_backend_guid(backend: Union[ggml_backend_t, int], /) -> int:
+@ggml_function(
+    "ggml_backend_guid",
+    [ggml_backend_t_ctypes],
+    ggml_guid_t_ctypes,
+)
+def ggml_backend_guid(
+    backend: Union[ggml_backend_t, int], /
+) -> Optional[ggml_guid_t]:
     ...
 
 

--- a/ggml/ggml.py
+++ b/ggml/ggml.py
@@ -12649,11 +12649,13 @@ def ggml_gallocr_new(
 # GGML_API ggml_gallocr_t ggml_gallocr_new_n(ggml_backend_buffer_type_t * bufts, int n_bufs);
 @ggml_function(
     "ggml_gallocr_new_n",
-    [ggml_backend_buffer_type_t_ctypes, ctypes.c_int],
+    [ctypes.POINTER(ggml_backend_buffer_type_t_ctypes), ctypes.c_int],
     ggml_gallocr_ctypes,
 )
 def ggml_gallocr_new_n(
-    bufts: Union[ggml_backend_buffer_type_t, int], n_bufs: int, /
+    bufts: "ctypes._Pointer[ggml_backend_buffer_type_t]",  # type: ignore
+    n_bufs: int,
+    /,
 ) -> Optional[ggml_gallocr]:
     ...
 


### PR DESCRIPTION
Sync public ggml ctypes bindings with the vendored headers.

- Bind `ggml_abort` and `ggml_backend_guid`
- Fix `ggml_gallocr_new_n` to accept a buffer type pointer array
