### PR TITLE
fix: sync ggml binding signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- fix: sync ggml binding signatures by @aisk in #170
+
 ## [0.0.43]
 
 - feat: update vendored ggml to 0.15.2 by @abetlen in #167

--- a/ggml/contrib/onnx.py
+++ b/ggml/contrib/onnx.py
@@ -14238,7 +14238,14 @@ class GgmlOnnxExecutionContext:
             raise RuntimeError("Failed to get GGML backend buffer base")
         alignment = ggml.ggml_backend_buffer_get_alignment(buffer)
         offset = (alignment - (base % alignment)) % alignment
-        ggml.ggml_backend_tensor_alloc(buffer, tensor, ctypes.c_void_p(base + offset))
+        status = ggml.ggml_backend_tensor_alloc(
+            buffer, tensor, ctypes.c_void_p(base + offset)
+        )
+        if status != ggml.GGML_STATUS_SUCCESS:
+            status_text = ggml.ggml_status_to_string(status).decode(
+                "utf-8", errors="replace"
+            )
+            raise RuntimeError(f"Failed to allocate GGML backend tensor: {status_text}")
 
     def alloc_backend_buffer_for_tensor(
         self, tensor: ggml.ggml_tensor_p

--- a/ggml/ggml.py
+++ b/ggml/ggml.py
@@ -11141,13 +11141,13 @@ def gguf_type_name(
     ...
 
 
-# GGML_API int    gguf_get_version    (const struct gguf_context * ctx);
+# GGML_API uint32_t gguf_get_version    (const struct gguf_context * ctx);
 @ggml_function(
     "gguf_get_version",
     [
         gguf_context_p_ctypes,
     ],
-    ctypes.c_int,
+    ctypes.c_uint32,
 )
 def gguf_get_version(
     ctx: gguf_context_p,
@@ -14524,7 +14524,7 @@ ggml_backend_eval_callback = ctypes.CFUNCTYPE(
 
 
 # // Compare the output of two backends
-# GGML_API bool ggml_backend_compare_graph_backend(ggml_backend_t backend1, ggml_backend_t backend2, struct ggml_cgraph * graph, ggml_backend_eval_callback callback, void * user_data);
+# GGML_API bool ggml_backend_compare_graph_backend(ggml_backend_t backend1, ggml_backend_t backend2, struct ggml_cgraph * graph, ggml_backend_eval_callback callback, void * user_data, struct ggml_tensor const * const * test_nodes, size_t num_test_nodes);
 @ggml_function(
     "ggml_backend_compare_graph_backend",
     [
@@ -14533,6 +14533,8 @@ ggml_backend_eval_callback = ctypes.CFUNCTYPE(
         ctypes.POINTER(ggml_cgraph),
         ggml_backend_eval_callback,
         ctypes.c_void_p,
+        ctypes.POINTER(ctypes.POINTER(ggml_tensor)),
+        ctypes.c_size_t,
     ],
     ctypes.c_bool,
 )
@@ -14542,12 +14544,14 @@ def ggml_backend_compare_graph_backend(
     graph: ggml_cgraph_p,
     callback,  # type: ignore
     user_data: Union[ctypes.c_void_p, int, None],
+    test_nodes: Optional[CtypesPointer[ggml_tensor_p]],
+    num_test_nodes: Union[ctypes.c_size_t, int],
 ) -> bool:
     ...
 
 
 # // Tensor initialization
-# GGML_API void ggml_backend_tensor_alloc(ggml_backend_buffer_t buffer, struct ggml_tensor * tensor, void * addr);
+# GGML_API enum ggml_status ggml_backend_tensor_alloc(ggml_backend_buffer_t buffer, struct ggml_tensor * tensor, void * addr);
 @ggml_function(
     "ggml_backend_tensor_alloc",
     [
@@ -14555,29 +14559,26 @@ def ggml_backend_compare_graph_backend(
         ctypes.POINTER(ggml_tensor),
         ctypes.c_void_p,
     ],
-    None,
+    ctypes.c_int,
 )
 def ggml_backend_tensor_alloc(
     buffer: Union[ggml_backend_buffer_t, int],
     tensor: ggml_tensor_p,
     addr: Union[ctypes.c_void_p, int, None],
     /,
-):
+) -> int:
     ...
 
 
-# GGML_API void ggml_backend_view_init(ggml_backend_buffer_t buffer, struct ggml_tensor * tensor);
+# GGML_API enum ggml_status ggml_backend_view_init(struct ggml_tensor * tensor);
 @ggml_function(
     "ggml_backend_view_init",
     [
-        ggml_backend_buffer_t_ctypes,
         ctypes.POINTER(ggml_tensor),
     ],
-    None,
+    ctypes.c_int,
 )
-def ggml_backend_view_init(
-    buffer: Union[ggml_backend_buffer_t, int], tensor: ggml_tensor_p, /
-):
+def ggml_backend_view_init(tensor: ggml_tensor_p, /) -> int:
     ...
 
 


### PR DESCRIPTION
Sync outdated ctypes signatures with the vendored ggml and GGUF headers.