### PR TITLE
release: bump version to 0.0.44

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.44]
+
 - ci: add Pyodide wheel builds by @abetlen in #171
 - fix: bind ggml abort and backend guid API by @aisk in #169
 - fix: sync updated gguf and backend binding signatures by @aisk in #170

--- a/ggml/__init__.py
+++ b/ggml/__init__.py
@@ -1,3 +1,3 @@
 from .ggml import *
 
-__version__ = "0.0.43"
+__version__ = "0.0.44"


### PR DESCRIPTION
Prepare the 0.0.44 release.

- Bump package version to 0.0.44
- Move unreleased changelog entries into 0.0.44
