### PR TITLE
docs: link usage docs to playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ pip install ggml-python --config-settings=cmake.args='-DGGML_CUDA=ON'
 
 # Usage
 
+You can also try this example in the browser using the [ggml-python playground](https://ggml-python.readthedocs.io/en/latest/playground/).
+
 ```python
 import ggml
 import ctypes

--- a/docs/index.md
+++ b/docs/index.md
@@ -120,6 +120,7 @@ Below are the available options for building ggml-python with additional options
 ## Basic Example
 
 Below is a simple example of using ggml-python low level api to compute the value of a function.
+You can also try this example in the browser using the [ggml-python playground](playground.md).
 
 ```python
 import ggml


### PR DESCRIPTION
Adds playground links from the usage documentation.

- Links README usage to the hosted playground.
- Links the getting started basic example to the playground page.
- Verified with `mkdocs build --strict`.
