### PR TITLE
release: bump version to 0.0.45

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.45]
+
 - feat: update vendored ggml to 0.15.3 and sync SYCL bindings by @abetlen in #177
 - docs: add JupyterLite browser playground by @abetlen in #173
 

--- a/ggml/__init__.py
+++ b/ggml/__init__.py
@@ -1,3 +1,3 @@
 from .ggml import *
 
-__version__ = "0.0.44"
+__version__ = "0.0.45"


### PR DESCRIPTION
Prepares the next ggml-python release.

- Bumps package version to `0.0.45`.
- Moves current unreleased changelog entries under `0.0.45`.
- Verified import reports `ggml.__version__ == "0.0.45"`.
