### PR TITLE
fix: derive ggml version from runtime library

### DIFF
--- a/ggml/ggml.py
+++ b/ggml/ggml.py
@@ -104,7 +104,12 @@ def load_shared_library(module_name: str, lib_base_name: str):
 
     for lib_name in lib_names:
         try:
-            with importlib_resources.as_file(importlib_resources.files(module_name).joinpath("lib", lib_name)) as p: # type: ignore
+            resource = (
+                importlib_resources.files(module_name)
+                .joinpath("lib")
+                .joinpath(lib_name)
+            )
+            with importlib_resources.as_file(resource) as p:  # type: ignore
                 p = cast(pathlib.Path, p)
                 if os.path.exists(p):
                     path = p

--- a/ggml/ggml.py
+++ b/ggml/ggml.py
@@ -103,6 +103,11 @@ def load_shared_library(module_name: str, lib_base_name: str):
     path: Optional[pathlib.Path] = None
 
     for lib_name in lib_names:
+        local_path = base_path / lib_name
+        if local_path.exists():
+            path = local_path
+            break
+
         try:
             resource = (
                 importlib_resources.files(module_name)

--- a/ggml/ggml.py
+++ b/ggml/ggml.py
@@ -306,10 +306,12 @@ GGML_EXIT_SUCCESS = 0
 # #define GGML_EXIT_ABORTED 1
 GGML_EXIT_ABORTED = 1
 
-GGML_VERSION_MAJOR = 0
-GGML_VERSION_MINOR = 15
-GGML_VERSION_PATCH = 3
-GGML_VERSION = "0.15.3"
+lib.ggml_version.argtypes = []
+lib.ggml_version.restype = ctypes.c_char_p
+GGML_VERSION = lib.ggml_version().decode("utf-8")
+GGML_VERSION_MAJOR, GGML_VERSION_MINOR, GGML_VERSION_PATCH = (
+    int(component) for component in GGML_VERSION.split(".")
+)
 
 GGML_ROPE_TYPE_NORMAL = 0
 GGML_ROPE_TYPE_NEOX = 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,9 @@ testpaths = "tests"
 target-version = "py38"
 extend-exclude = ["ggml/contrib/onnx.py", "tests/test_ggml_onnx.py"]
 
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]
+
 [tool.ruff.lint.per-file-ignores]
 "ggml/__init__.py" = ["F403"]
 

--- a/tests/test_ggml.py
+++ b/tests/test_ggml.py
@@ -7,6 +7,17 @@ import ggml
 import numpy as np
 
 
+def test_ggml_version_constants_match_runtime_library():
+    version = ggml.ggml_version().decode("utf-8")
+
+    assert ggml.GGML_VERSION == version
+    assert (
+        ggml.GGML_VERSION_MAJOR,
+        ggml.GGML_VERSION_MINOR,
+        ggml.GGML_VERSION_PATCH,
+    ) == tuple(int(component) for component in version.split("."))
+
+
 def test_ggml():
     assert ggml.GGML_FILE_VERSION == 2
 


### PR DESCRIPTION
Derive ggml version constants from the runtime library and restore compatibility with supported Python and Ruff versions.